### PR TITLE
Fix missing Supabase dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.5"
+    "next": "15.3.5",
+    "@supabase/supabase-js": "^2.39.8"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- add `@supabase/supabase-js` to package dependencies

## Testing
- `npm install @supabase/supabase-js` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68765cd764288330b147ead80128493b