### PR TITLE
Improve reset flow and team management

### DIFF
--- a/app/setup/page.tsx
+++ b/app/setup/page.tsx
@@ -1,9 +1,13 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { supabase } from "../../lib/supabaseBrowser";
 
 type Player = {
   id: number;
   name: string;
+  offense: number;
+  defense: number;
+  user_id: string;
 };
 
 type Team = {
@@ -12,27 +16,54 @@ type Team = {
 };
 
 export default function SetupPage() {
-  // placeholder players list
-  const [players] = useState<Player[]>([
-    { id: 1, name: "Player 1" },
-    { id: 2, name: "Player 2" },
-    { id: 3, name: "Player 3" },
-    { id: 4, name: "Player 4" },
-  ]);
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [present, setPresent] = useState<number[]>([]);
   const [teams, setTeams] = useState<Team[]>([]);
   const [selected, setSelected] = useState<number[]>([]);
+  const [editingTeam, setEditingTeam] = useState<number | null>(null);
   const [tournamentName, setTournamentName] = useState("");
+  const [user, setUser] = useState<any>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: userData } = await supabase.auth.getUser();
+      setUser(userData.user);
+      if (userData.user) {
+        const { data } = await supabase
+          .from('players')
+          .select('*')
+          .eq('user_id', userData.user.id);
+        setPlayers(data || []);
+        setPresent((data || []).map((p) => p.id));
+      }
+    };
+    load();
+  }, []);
 
   const addTeam = () => {
     if (selected.length === 2) {
-      const nextId = teams.length ? teams[teams.length - 1].id + 1 : 1;
       const teamPlayers = players.filter((p) => selected.includes(p.id)) as [
         Player,
         Player
       ];
-      setTeams([...teams, { id: nextId, players: teamPlayers }]);
+      if (editingTeam !== null) {
+        setTeams((prev) =>
+          prev.map((t) =>
+            t.id === editingTeam ? { id: t.id, players: teamPlayers } : t
+          )
+        );
+        setEditingTeam(null);
+      } else {
+        const nextId = teams.length ? teams[teams.length - 1].id + 1 : 1;
+        setTeams([...teams, { id: nextId, players: teamPlayers }]);
+      }
       setSelected([]);
     }
+  };
+
+  const editTeam = (team: Team) => {
+    setSelected(team.players.map((p) => p.id));
+    setEditingTeam(team.id);
   };
 
   const createTournament = () => {
@@ -45,9 +76,33 @@ export default function SetupPage() {
     <div className="space-y-4">
       <h2 className="text-xl font-bold">Tournament Setup</h2>
       <div>
-        <h3 className="font-semibold">Create Teams</h3>
+        <h3 className="font-semibold">Players Present</h3>
         <div className="space-x-2">
           {players.map((p) => (
+            <label key={p.id} className="space-x-1">
+              <input
+                type="checkbox"
+                checked={present.includes(p.id)}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    setPresent([...present, p.id]);
+                  } else {
+                    setPresent(present.filter((id) => id !== p.id));
+                    setSelected(selected.filter((id) => id !== p.id));
+                  }
+                }}
+              />
+              <span>{p.name}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+      <div>
+        <h3 className="font-semibold">Create Teams</h3>
+        <div className="space-x-2">
+          {players
+            .filter((p) => present.includes(p.id))
+            .map((p) => (
             <label key={p.id} className="space-x-1">
               <input
                 type="checkbox"
@@ -64,13 +119,21 @@ export default function SetupPage() {
             </label>
           ))}
           <button className="border px-2" onClick={addTeam} disabled={selected.length !== 2}>
-            Add Team
+            {editingTeam ? 'Update Team' : 'Add Team'}
           </button>
+          {editingTeam && (
+            <button className="border px-2" onClick={() => {setEditingTeam(null); setSelected([]);}}>
+              Cancel
+            </button>
+          )}
         </div>
         <ul className="list-disc pl-5">
           {teams.map((t) => (
             <li key={t.id}>
               Team {t.id}: {t.players[0].name} & {t.players[1].name}
+              <button className="ml-2 text-blue-600" onClick={() => editTeam(t)}>
+                Edit
+              </button>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- handle `PASSWORD_RECOVERY` event so user can set a new password
- associate players with the current user and allow skill editing
- fetch players for team setup, allow marking presence and editing teams

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68768175763c8330b4d26f5f13a92313