### PR TITLE
Add run/view buttons for tournaments

### DIFF
--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { useParams } from "next/navigation";
+
+export default function TournamentViewPage() {
+  const params = useParams();
+  const id = params?.id as string;
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold">Tournament {id}</h2>
+      <p>Results and details will appear here.</p>
+    </div>
+  );
+}

--- a/app/tournaments/page.tsx
+++ b/app/tournaments/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { supabase } from "../../lib/supabaseBrowser";
 
 interface Tournament {
@@ -19,9 +20,15 @@ export default function TournamentsPage() {
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-bold">Tournaments</h2>
-      <ul className="list-disc pl-5">
-        {tournaments.map(t => (
-          <li key={t.id}>{t.name}</li>
+      <ul className="list-disc pl-5 space-y-1">
+        {tournaments.map((t) => (
+          <li key={t.id} className="flex items-center gap-2">
+            <span className="flex-1">{t.name}</span>
+            <Link href="/run" className="border px-2 py-0.5">Run</Link>
+            <Link href={`/tournaments/${t.id}`} className="border px-2 py-0.5">
+              View
+            </Link>
+          </li>
         ))}
       </ul>
     </div>

--- a/components/NavSelect.tsx
+++ b/components/NavSelect.tsx
@@ -15,7 +15,6 @@ export default function NavSelect() {
       </option>
       <option value="/players">Players</option>
       <option value="/tournaments/setup">Tournament Setup</option>
-      <option value="/run">Tournament Run</option>
       <option value="/teams">Teams</option>
       <option value="/tournaments">Tournaments</option>
     </select>


### PR DESCRIPTION
## Summary
- remove the Run page from the navigation dropdown
- list Run and View actions next to each tournament
- create a placeholder tournament view page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878d598996c8330ba23d6d99e51c2fc