### PR TITLE
Add knockout schedule with fireworks

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,28 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* simple fireworks animation used when a tournament winner is decided */
+.fireworks-container {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 50;
+}
+
+.firework {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: firework 700ms ease-out forwards;
+}
+
+@keyframes firework {
+  to {
+    transform: translate3d(var(--x), var(--y), 0) scale(0);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- support advancing rounds for knockout tournaments
- add simple fireworks animation to globals
- trigger fireworks and next round creation on the run page

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'next' or its corresponding type declarations)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879ef539b108330a97115af6dfd57aa