### PR TITLE
Fix duplication in knockout schedule and longer fireworks

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -40,7 +40,8 @@ body {
   height: 6px;
   border-radius: 50%;
   background: currentColor;
-  animation: firework 700ms ease-out forwards;
+  /* extend the animation so the fireworks are visible for longer */
+  animation: firework 3s ease-out forwards;
 }
 
 @keyframes firework {

--- a/app/run/[id]/page.tsx
+++ b/app/run/[id]/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useParams } from "next/navigation";
 import { supabase } from "../../../lib/supabaseBrowser";
 
@@ -29,8 +29,13 @@ export default function TournamentRunPage() {
   const [teams, setTeams] = useState<Team[]>([]);
   const [scores, setScores] = useState<Record<number, { a: number; b: number }>>({});
   const [celebrated, setCelebrated] = useState(false);
+  // ensures initial match generation only happens once
+  const initialized = useRef(false);
 
   useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
+
     const load = async () => {
       const { data: userData } = await supabase.auth.getUser();
       const currentUser = userData.user;
@@ -102,7 +107,7 @@ export default function TournamentRunPage() {
   }, [id]);
 
   const teamName = (tid: number | null | undefined) =>
-    teams.find((t) => t.id === tid)?.name || `Team ${tid}`;
+    teams.find((t) => t.id === tid)?.name || "Unknown team";
 
   const triggerFireworks = () => {
     const container = document.createElement("div");
@@ -118,7 +123,8 @@ export default function TournamentRunPage() {
       container.appendChild(el);
     }
     document.body.appendChild(container);
-    setTimeout(() => container.remove(), 800);
+    // keep the fireworks visible for a little longer so users can enjoy them
+    setTimeout(() => container.remove(), 3000);
   };
 
   const nextRound = async () => {

--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -52,7 +52,7 @@ export default function TournamentViewPage() {
   }, [id]);
 
   const teamName = (tid: number | null | undefined) =>
-    teams.find((t) => t.id === tid)?.name || `Team ${tid}`;
+    teams.find((t) => t.id === tid)?.name || "Unknown team";
 
   const phases = Array.from(new Set(matches.map((m) => m.phase))).sort(
     (a, b) =>


### PR DESCRIPTION
## Summary
- avoid duplicate match creation when StrictMode runs effects twice
- show `Unknown team` instead of the team id when a name can't be found
- keep fireworks visible for 3 seconds

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879f35538688330ae88ef4f3bd5700b