### PR TITLE
Add OpenAI balanced teams feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+OPENAI_API_KEY=your_openai_api_key

--- a/app/api/balanced-teams/route.ts
+++ b/app/api/balanced-teams/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const { players } = await req.json();
+
+  const prompt = `You are a helpful assistant. Create balanced two-player teams from the provided list of players. Each player has an id, offense and defense skill. Make the teams so that offense and defense are as evenly distributed as possible across all teams. Use names from The Lord of the Rings for the teams. Respond with JSON only in the format {"teams": [{"name": "string", "playerIds": [id1, id2]}]}.`;
+
+  try {
+    const aiRes = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [
+          { role: "system", content: prompt },
+          { role: "user", content: JSON.stringify(players) },
+        ],
+        temperature: 0.7,
+      }),
+    });
+
+    const data = await aiRes.json();
+    const text = data.choices?.[0]?.message?.content || "{}";
+    const json = JSON.parse(text);
+    return NextResponse.json(json);
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "failed" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add OpenAI API key to example env file
- create new API route to call OpenAI for balanced team generation
- integrate balanced team generation on Teams page with a new button

## Testing
- `npx prettier -w app/teams/page.tsx app/api/balanced-teams/route.ts`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a08d1418c83309c40aa3f7b05a2b0