### PR TITLE
Improve balanced team creation error handling

### DIFF
--- a/app/api/balanced-teams/route.ts
+++ b/app/api/balanced-teams/route.ts
@@ -36,8 +36,19 @@ export async function POST(req: NextRequest) {
 
     debug.push("OpenAI response received");
 
+    if (!aiRes.ok) {
+      debug.push(`OpenAI request failed: ${aiRes.status}`);
+      const error = await aiRes.text();
+      debug.push(error);
+      return NextResponse.json({ error: "openai failed", debug }, { status: 500 });
+    }
+
     const data = await aiRes.json();
-    const text = data.choices?.[0]?.message?.content || "{}";
+    if (!data.choices || data.choices.length === 0) {
+      debug.push("OpenAI returned no choices");
+      return NextResponse.json({ error: "openai failed", debug }, { status: 500 });
+    }
+    const text = data.choices[0].message?.content || "{}";
     debug.push("Parsing response...");
     const json = JSON.parse(text);
     debug.push("Returning teams");


### PR DESCRIPTION
## Summary
- enhance `balanced-teams` route to check the OpenAI response status
- return an error when no choices are received

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a1a6315f4833086e2bdc10b3c3998