### PR TITLE
Improve team display and AI balancing

### DIFF
--- a/app/api/balanced-teams/route.ts
+++ b/app/api/balanced-teams/route.ts
@@ -4,7 +4,7 @@ export async function POST(req: NextRequest) {
   const { players } = await req.json();
 
   const debug: string[] = [];
-  const prompt = `You are a helpful assistant. Create balanced two-player teams from the provided list of players. Each player has an id, offense and defense skill. Make the teams so that offense and defense are as evenly distributed as possible across all teams. Use names from The Lord of the Rings for the teams. Respond with JSON only in the format {"teams": [{"name": "string", "playerIds": [id1, id2]}]}.`;
+  const prompt = `You are a helpful assistant. Create balanced two-player teams from the provided list of players. Each player has an id, offense and defense skill. In each team one player will attack and the other will defend, so a team's offense is the higher offense value of its players and the defense is the higher defense value. Compose the pairs so that all teams have comparable offense and defense ratings and no team is an obvious favourite. Use names from The Lord of the Rings for the team names. Respond with JSON only in the format {"teams": [{"name": "string", "playerIds": [id1, id2]}]}.`;
 
   debug.push("Retrieving API key...");
   const apiKey = process.env.OPENAI_API_KEY;

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -144,17 +144,24 @@ export default function PlayersPage() {
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
+        <p className="text-sm text-gray-600">
+          Set the player's skill levels using the sliders below. The first
+          slider controls the Offence skill, the second controls the Defence
+          skill.
+        </p>
         <input
-          type="number"
-          className="border p-1"
-          placeholder="Offense"
+          type="range"
+          min="0"
+          max="10"
+          className="w-full"
           value={offense}
           onChange={(e) => setOffense(Number(e.target.value))}
         />
         <input
-          type="number"
-          className="border p-1"
-          placeholder="Defense"
+          type="range"
+          min="0"
+          max="10"
+          className="w-full"
           value={defense}
           onChange={(e) => setDefense(Number(e.target.value))}
         />

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -220,6 +220,20 @@ export default function TeamsPage() {
   const playerName = (id: number) =>
     players.find((p) => p.id === id)?.name || "";
 
+  const teamOffense = (ids: number[]) => {
+    const values = ids.map(
+      (pid) => players.find((p) => p.id === pid)?.offense ?? 0,
+    );
+    return Math.max(...values);
+  };
+
+  const teamDefense = (ids: number[]) => {
+    const values = ids.map(
+      (pid) => players.find((p) => p.id === pid)?.defense ?? 0,
+    );
+    return Math.max(...values);
+  };
+
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-bold">Teams</h2>
@@ -279,6 +293,9 @@ export default function TeamsPage() {
           <li key={t.id} className="flex items-center gap-2 border-b pb-1">
             <span className="flex-1">
               {t.name}: {t.playerIds.map(playerName).join(" & ")}
+              <span className="ml-2 text-sm text-gray-500">
+                O:{teamOffense(t.playerIds)} D:{teamDefense(t.playerIds)}
+              </span>
             </span>
             <button className="border px-2 py-0.5" onClick={() => editTeam(t)}>
               Edit


### PR DESCRIPTION
## Summary
- explain skills when creating a new player and use range sliders
- show offence and defence rating for each team
- tweak AI prompt for better balanced team generation

## Testing
- `npm run lint` *(fails: `next` not found due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_687a27de4f588330adc41937bdea41c9