### PR TITLE
Fix password reset flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
    - **players** with columns `id` (uuid, primary key), `name` (text), `offense` (int4), `defense` (int4).
    - **tournaments** with columns `id` (uuid, primary key) and `name` (text).
 3. Under **Authentication** enable email login and disable anonymous sign ups.
-4. Set the SMTP settings to use your [Resend](https://resend.com) credentials so Supabase will send verification codes via Resend.
-5. Grab the project URL and anon key from the Supabase settings and add them to an `.env` file using the variables shown in `.env.example`.
+4. In the **Email** settings choose **Email OTP** for "Confirm signup" so new accounts receive a numeric code instead of a magic link. Also set the password recovery redirect URL to `<your site>/reset` so the reset link leads to the page for choosing a new password.
+5. Set the SMTP settings to use your [Resend](https://resend.com) credentials so Supabase will send the emails via Resend.
+6. Grab the project URL and anon key from the Supabase settings and add them to an `.env` file using the variables shown in `.env.example`.
 
 ## Authentication
 

--- a/app/reset/page.tsx
+++ b/app/reset/page.tsx
@@ -1,0 +1,9 @@
+import LoginOverlay from "../../components/LoginOverlay";
+
+export default function ResetPage() {
+  return (
+    <LoginOverlay>
+      <div />
+    </LoginOverlay>
+  );
+}

--- a/components/LoginOverlay.tsx
+++ b/components/LoginOverlay.tsx
@@ -67,7 +67,9 @@ export default function LoginOverlay({ children }: { children: React.ReactNode }
   };
 
   const resetPassword = async () => {
-    const { error } = await supabase.auth.resetPasswordForEmail(email);
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${location.origin}/reset`,
+    });
     if (error) setMessage(error.message);
     else setMessage("Check your email for a reset link.");
   };


### PR DESCRIPTION
## Summary
- document Supabase email OTP and password reset URL setup
- send password reset emails to a `/reset` page
- add minimal reset page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a40d696d88330a9391b5a0249db45