### PR TITLE
Validate skill ranges on player forms

### DIFF
--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -45,6 +45,10 @@ export default function PlayersPage() {
 
   const addOrUpdate = async () => {
     if (!user) return;
+    if (offense < 0 || offense > 10 || defense < 0 || defense > 10) {
+      alert('Skills must be between 0 and 10');
+      return;
+    }
     if (editing !== null) {
       await supabase
         .from('players')
@@ -79,6 +83,15 @@ export default function PlayersPage() {
 
   const updateSkills = async (id: number) => {
     if (!user) return;
+    if (
+      skillOffense < 0 ||
+      skillOffense > 10 ||
+      skillDefense < 0 ||
+      skillDefense > 10
+    ) {
+      alert('Skills must be between 0 and 10');
+      return;
+    }
     await supabase
       .from('players')
       .update({ offense: skillOffense, defense: skillDefense })


### PR DESCRIPTION
## Summary
- add validation to make sure offense and defense are between 0 and 10 when creating or updating a player
- abort create/update if invalid values are provided

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a4f0516d08330852d271b304872e8