### PR TITLE
Add debug info for AI tournament scheduling

### DIFF
--- a/app/api/best-schedule/route.ts
+++ b/app/api/best-schedule/route.ts
@@ -2,8 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(req: NextRequest) {
   const { teams } = await req.json();
+  const debug: string[] = [];
   if (!Array.isArray(teams)) {
-    return NextResponse.json({ error: "invalid teams" }, { status: 400 });
+    debug.push("Invalid teams payload");
+    return NextResponse.json({ error: "invalid teams", debug }, { status: 400 });
   }
 
   const isPower = (n: number) => (n & (n - 1)) === 0 && n !== 0;
@@ -14,17 +16,20 @@ export async function POST(req: NextRequest) {
         matches.push({ round: 1, teamA: teams[i].id, teamB: teams[i + 1].id });
       }
     }
-    return NextResponse.json({ strategy: "knockout", matches });
+    debug.push("Number of teams is power of two - no AI needed");
+    return NextResponse.json({ strategy: "knockout", matches, debug });
   }
 
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
-    return NextResponse.json({ error: "Missing API key" }, { status: 500 });
+    debug.push("OPENAI_API_KEY not found");
+    return NextResponse.json({ error: "Missing API key", debug }, { status: 500 });
   }
 
   const prompt =
     'You are an expert tournament organiser. Given a list of teams with their ids and names, create a schedule that minimises the number of rounds needed to determine a winner. Respond only with JSON in the format {"strategy":"string","matches":[{"round":1,"teamA":id,"teamB":id}]}.';
 
+  debug.push("Key retrieved, contacting OpenAI...");
   try {
     const aiRes = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
@@ -42,21 +47,29 @@ export async function POST(req: NextRequest) {
       }),
     });
 
+    debug.push("OpenAI response received");
     if (!aiRes.ok) {
+      debug.push(`OpenAI request failed: ${aiRes.status}`);
       const err = await aiRes.text();
-      return NextResponse.json({ error: err }, { status: 500 });
+      debug.push(err);
+      return NextResponse.json({ error: err, debug }, { status: 500 });
     }
 
     const data = await aiRes.json();
     const text = data.choices?.[0]?.message?.content || "{}";
     let json;
     try {
+      debug.push("Parsing response...");
       json = JSON.parse(text);
     } catch {
+      debug.push("Failed to parse response");
       json = {};
     }
-    return NextResponse.json(json);
+    debug.push("Returning schedule");
+    return NextResponse.json({ ...json, debug });
   } catch (err: any) {
-    return NextResponse.json({ error: err?.message || 'failed' }, { status: 500 });
+    console.error(err);
+    debug.push(`Error: ${err?.message || 'unknown'}`);
+    return NextResponse.json({ error: err?.message || 'failed', debug }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- enhance `/api/best-schedule` with detailed debug logging
- display debug output on the tournament page

## Testing
- `npm run lint` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a74ef5ea48330bf46abcabd3b18ef