### PR TITLE
Refreshed navigation and tournaments UI

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,14 +29,12 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <LoginOverlay>
-          <header className="p-4 flex flex-col">
-            <div className="flex items-center gap-4">
+          <header className="p-4 border-b">
+            <div className="flex items-center justify-between">
               <a href="/" className="flex items-center gap-2 text-xl font-bold">
                 <img src="/babyfoot.svg" alt="Babyfoot" className="w-6 h-6" />
                 My Tournament App
               </a>
-            </div>
-            <div className="flex items-center gap-2 mt-2">
               <AuthButtons />
             </div>
             <NavButtons />

--- a/app/tournaments/page.tsx
+++ b/app/tournaments/page.tsx
@@ -1,19 +1,26 @@
 "use client";
 import { useEffect, useState } from "react";
-import Link from "next/link";
+import TournamentsView from "../../components/TournamentsView";
 import { supabase } from "../../lib/supabaseBrowser";
+import { useRouter } from "next/navigation";
 
 interface Team {
   id: number;
   name: string;
 }
 
+interface TournamentTeam {
+  id: number;
+}
+
 interface Tournament {
   id: number;
   name: string;
+  teams: TournamentTeam[];
 }
 
 export default function TournamentsPage() {
+  const router = useRouter();
   const [user, setUser] = useState<any>(null);
   const [teams, setTeams] = useState<Team[]>([]);
   const [selected, setSelected] = useState<number[]>([]);
@@ -35,9 +42,14 @@ export default function TournamentsPage() {
 
         const { data: tourData } = await supabase
           .from("tournaments")
-          .select("*")
+          .select("id, name, teams(id)")
           .eq("user_id", userData.user.id);
-        setTournaments(tourData || []);
+        const converted = (tourData || []).map((t) => ({
+          id: t.id,
+          name: t.name,
+          teams: t.teams || [],
+        }));
+        setTournaments(converted);
       }
     };
     load();
@@ -66,7 +78,10 @@ export default function TournamentsPage() {
         .update({ tournament_id: inserted.id })
         .in("id", selected)
         .eq("user_id", user.id);
-      setTournaments((prev) => [...prev, inserted]);
+      setTournaments((prev) => [
+        ...prev,
+        { id: inserted.id, name: inserted.name, teams: selected.map((id) => ({ id })) },
+      ]);
     }
 
     const teamsForSchedule = teams.filter((t) => selected.includes(t.id));
@@ -225,41 +240,13 @@ export default function TournamentsPage() {
           <pre className="border p-2 text-sm whitespace-pre-wrap">{debug.join("\n")}</pre>
         )}
       </div>
-      <div className="space-y-4">
-        <h2 className="text-xl font-bold">Tournaments</h2>
-        <ul className="space-y-1 bg-gray-100 p-2 rounded">
-          {tournaments.map((t) => (
-            <li key={t.id} className="flex items-center gap-2 border-b pb-1">
-              <span className="flex-1">{t.name}</span>
-              <Link
-                href={`/run/${t.id}`}
-                className="border px-2 py-0.5 border-red-500 bg-red-500 hover:bg-red-600 text-white"
-              >
-                Run
-              </Link>
-              <Link
-                href={`/tournaments/${t.id}`}
-                className="border px-2 py-0.5 border-yellow-500 bg-yellow-500 hover:bg-yellow-600 text-black"
-              >
-                View
-              </Link>
-              <button
-                className="border border-blue-500 bg-blue-500 hover:bg-blue-600 text-white px-2 py-0.5"
-                onClick={() => generateSchedule(t.id)}
-                disabled={loadingId === t.id}
-              >
-                {loadingId === t.id ? "Building..." : "AI Schedule"}
-              </button>
-              <button
-                className="border border-orange-500 bg-orange-500 hover:bg-orange-600 text-white px-2 py-0.5"
-                onClick={() => deleteTournament(t.id)}
-              >
-                Delete
-              </button>
-            </li>
-          ))}
-        </ul>
-      </div>
+      <TournamentsView
+        tournaments={tournaments}
+        onRun={(id) => router.push(`/run/${id}`)}
+        onView={(id) => router.push(`/tournaments/${id}`)}
+        onSchedule={generateSchedule}
+        onDelete={deleteTournament}
+      />
     </div>
   );
 }

--- a/components/AuthButtons.tsx
+++ b/components/AuthButtons.tsx
@@ -37,19 +37,19 @@ export default function AuthButtons() {
     // Login overlay appears automatically when no user
   };
 
-  return (
-    <>
-      {user && <span>{user.email}</span>}
-      <button
-        className={
-          user
-            ? "bg-red-500 hover:bg-red-600 text-white px-2"
-            : "bg-green-500 hover:bg-green-600 text-white px-2"
-        }
-        onClick={user ? logout : login}
-      >
-        {user ? "Logout" : "Login"}
-      </button>
-    </>
+  return user ? (
+    <button
+      className="bg-rose-100 text-rose-700 text-sm px-3 py-1 rounded hover:bg-rose-200"
+      onClick={logout}
+    >
+      Logout
+    </button>
+  ) : (
+    <button
+      className="bg-green-500 hover:bg-green-600 text-white text-sm px-3 py-1 rounded"
+      onClick={login}
+    >
+      Login
+    </button>
   );
 }

--- a/components/NavButtons.tsx
+++ b/components/NavButtons.tsx
@@ -1,27 +1,29 @@
 "use client";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 export default function NavButtons() {
+  const pathname = usePathname();
+  const tabs = [
+    { href: "/players", label: "Players" },
+    { href: "/teams", label: "Teams" },
+    { href: "/tournaments", label: "Tournaments" },
+  ];
+
   return (
-    <div className="flex gap-2 mt-2">
-      <Link
-        href="/players"
-        className="border bg-gray-200 px-2 py-0.5"
-      >
-        Players
-      </Link>
-      <Link
-        href="/teams"
-        className="border bg-gray-200 px-2 py-0.5"
-      >
-        Teams
-      </Link>
-      <Link
-        href="/tournaments"
-        className="border bg-gray-200 px-2 py-0.5"
-      >
-        Tournaments
-      </Link>
+    <div className="flex gap-2 mt-4 border-b">
+      {tabs.map((tab) => {
+        const active = pathname === tab.href || pathname.startsWith(`${tab.href}/`);
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className={`px-3 py-1 text-sm rounded-t-md ${active ? "bg-white border-x border-t border-gray-300" : "bg-gray-100 hover:bg-gray-200"}`}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
     </div>
   );
 }

--- a/components/TournamentsView.tsx
+++ b/components/TournamentsView.tsx
@@ -1,0 +1,51 @@
+import { Button } from "@/components/ui/button";
+
+interface Tournament {
+  id: number;
+  name: string;
+  teams: { id: number }[];
+}
+
+interface Props {
+  tournaments: Tournament[];
+  onRun: (id: number) => void;
+  onView: (id: number) => void;
+  onSchedule: (id: number) => void;
+  onDelete: (id: number) => void;
+}
+
+export default function TournamentsView({ tournaments, onRun, onView, onSchedule, onDelete }: Props) {
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-6">
+      {/* Header */}
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-semibold">Tournaments</h2>
+        <Button variant="outline" className="text-sm">
+          Create New Tournament
+        </Button>
+      </div>
+
+      {/* Tournament List */}
+      <div className="space-y-4">
+        {tournaments.map((tournament) => (
+          <div
+            key={tournament.id}
+            className="flex flex-col sm:flex-row justify-between items-start sm:items-center bg-white border border-gray-200 rounded-xl shadow-sm p-4"
+          >
+            <div>
+              <h3 className="text-lg font-medium">{tournament.name}</h3>
+              <p className="text-sm text-gray-500">{tournament.teams.length} teams</p>
+            </div>
+
+            <div className="flex flex-wrap gap-2 mt-3 sm:mt-0">
+              <Button className="bg-red-500 hover:bg-red-600" onClick={() => onRun(tournament.id)}>Run</Button>
+              <Button className="bg-amber-500 hover:bg-amber-600" onClick={() => onView(tournament.id)}>View</Button>
+              <Button className="bg-blue-500 hover:bg-blue-600" onClick={() => onSchedule(tournament.id)}>AI Schedule</Button>
+              <Button variant="destructive" onClick={() => onDelete(tournament.id)}>Delete</Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,15 @@
+export function Button({ children, className = "", onClick, variant = "default" }) {
+  const base =
+    "inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-lg transition";
+  const variants = {
+    default: "bg-emerald-600 text-white hover:bg-emerald-700",
+    outline: "border border-gray-300 text-gray-800 hover:bg-gray-100",
+    destructive: "bg-red-600 text-white hover:bg-red-700",
+  };
+
+  return (
+    <button className={`${base} ${variants[variant] || variant} ${className}`} onClick={onClick}>
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- make logout button compact
- redesign navigation as tabs with active highlight
- restructure header layout
- add reusable Button component
- add TournamentsView component and integrate into tournaments page
- fix Tournament type mismatch in tournaments page

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687b456d22e4833082f3cde55dd30cdc