### PR TITLE
Improve tournaments page layout

### DIFF
--- a/components/TournamentsView.tsx
+++ b/components/TournamentsView.tsx
@@ -1,5 +1,10 @@
 import { Button } from "@/components/ui/button";
 
+interface Team {
+  id: number;
+  name: string;
+}
+
 interface Tournament {
   id: number;
   name: string;
@@ -8,42 +13,92 @@ interface Tournament {
 
 interface Props {
   tournaments: Tournament[];
+  teams: Team[];
+  onSchedule: React.FormEventHandler<HTMLFormElement>;
+  onCreate: React.MouseEventHandler<HTMLButtonElement>;
   onRun: (id: number) => void;
   onView: (id: number) => void;
   onDelete: (id: number) => void;
 }
 
-export default function TournamentsView({ tournaments, onRun, onView, onDelete }: Props) {
+export default function TournamentsView({
+  tournaments,
+  teams,
+  onSchedule,
+  onCreate,
+  onRun,
+  onView,
+  onDelete,
+}: Props) {
   return (
-    <div className="max-w-3xl mx-auto p-6 space-y-6">
-      {/* Header */}
-      <div className="flex justify-between items-center">
-        <h2 className="text-2xl font-semibold">Tournaments</h2>
-        <Button variant="outline" className="text-sm">
-          Create New Tournament
-        </Button>
-      </div>
+    <div className="max-w-3xl mx-auto p-6 space-y-8">
+      {/* Tournament Setup */}
+      <section className="bg-white border border-gray-200 rounded-xl shadow-sm p-5 space-y-4">
+        <h2 className="text-xl font-semibold">Tournament Setup</h2>
 
-      {/* Tournament List */}
-      <div className="space-y-4">
+        <form onSubmit={onSchedule} className="space-y-4">
+          <input
+            type="text"
+            name="tournamentName"
+            placeholder="Tournament name"
+            required
+            className="w-full px-4 py-2 border border-gray-300 rounded-md text-sm"
+          />
+
+          <div>
+            <label className="block font-medium mb-1 text-sm">Select Teams</label>
+            <div className="flex flex-wrap gap-3 max-h-32 overflow-y-auto">
+              {teams.map((team) => (
+                <label key={team.id} className="flex items-center gap-1 text-sm">
+                  <input
+                    type="checkbox"
+                    name="teamSelection"
+                    value={team.id}
+                    className="text-emerald-600 rounded"
+                  />
+                  {team.name}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <Button type="submit" className="mt-2 bg-emerald-600 hover:bg-emerald-700">
+            AI Schedule
+          </Button>
+        </form>
+      </section>
+
+      {/* Tournaments List */}
+      <section className="space-y-4">
+        <div className="flex justify-between items-center">
+          <h2 className="text-xl font-semibold">Tournaments</h2>
+          <Button variant="outline" onClick={onCreate}>Create New Tournament</Button>
+        </div>
+
         {tournaments.map((tournament) => (
           <div
             key={tournament.id}
-            className="flex flex-col sm:flex-row justify-between items-start sm:items-center bg-white border border-gray-200 rounded-xl shadow-sm p-4"
+            className="bg-slate-50 border border-gray-200 rounded-xl px-5 py-4 shadow-sm flex flex-col sm:flex-row justify-between items-start sm:items-center"
           >
-            <div>
-              <h3 className="text-lg font-medium">{tournament.name}</h3>
-              <p className="text-sm text-gray-500">{tournament.teams.length} teams</p>
+            <div className="text-sm space-y-1">
+              <div className="text-base font-medium">{tournament.name}</div>
+              <div className="text-gray-500">{tournament.teams.length} teams</div>
             </div>
 
             <div className="flex flex-wrap gap-2 mt-3 sm:mt-0">
-              <Button className="bg-red-500 hover:bg-red-600" onClick={() => onRun(tournament.id)}>Run</Button>
-              <Button className="bg-amber-500 hover:bg-amber-600" onClick={() => onView(tournament.id)}>View</Button>
-              <Button variant="destructive" onClick={() => onDelete(tournament.id)}>Delete</Button>
+              <Button className="bg-red-500 hover:bg-red-600" onClick={() => onRun(tournament.id)}>
+                Run
+              </Button>
+              <Button className="bg-emerald-600 hover:bg-emerald-700" onClick={() => onView(tournament.id)}>
+                View
+              </Button>
+              <Button variant="destructive" onClick={() => onDelete(tournament.id)}>
+                Delete
+              </Button>
             </div>
           </div>
         ))}
-      </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- revamp `TournamentsView` component to match Players/Teams UI
- refactor tournaments page to use new component API

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687ba1920a3083308cd8c6ff557d6507