### PR TITLE
Implement modern header component

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import NavButtons from "../components/NavButtons";
-import AuthButtons from "../components/AuthButtons";
+import Header from "../components/Header";
 import LoginOverlay from "../components/LoginOverlay";
 
 const geistSans = Geist({
@@ -29,16 +28,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <LoginOverlay>
-          <header className="p-4 border-b">
-            <div className="flex items-center justify-between">
-              <a href="/" className="flex items-center gap-2 text-xl font-bold">
-                <img src="/babyfoot.svg" alt="Babyfoot" className="w-6 h-6" />
-                My Tournament App
-              </a>
-              <AuthButtons />
-            </div>
-            <NavButtons />
-          </header>
+          <Header />
           <main className="p-4">{children}</main>
         </LoginOverlay>
       </body>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { supabase } from "../lib/supabaseBrowser";
+
+const tabs = [
+  { name: "Players", href: "/players" },
+  { name: "Teams", href: "/teams" },
+  { name: "Tournaments", href: "/tournaments" },
+];
+
+export default function Header() {
+  const pathname = usePathname();
+  const [userEmail, setUserEmail] = useState<string | null>(null);
+
+  useEffect(() => {
+    supabase.auth
+      .getUser()
+      .then(({ data, error }) => {
+        if (error) {
+          console.error("getUser error", error.message);
+        }
+        setUserEmail(data.user?.email ?? null);
+      })
+      .catch((err) => {
+        console.error("getUser failed", err?.message);
+        setUserEmail(null);
+      });
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {
+      setUserEmail(session?.user?.email ?? null);
+    });
+    return () => {
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  const onLogout = async () => {
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      console.error("logout error", error.message);
+    }
+  };
+
+  return (
+    <header className="bg-white border-b border-gray-200">
+      <div className="max-w-4xl mx-auto px-4 py-4 flex flex-col sm:flex-row justify-between items-center gap-3 sm:gap-0">
+        {/* Left: App identity */}
+        <div className="flex items-center gap-2">
+          <span className="text-2xl">🤖</span>
+          <div>
+            <h1 className="text-lg font-semibold leading-tight">My Tournament App</h1>
+            <p className="text-xs text-gray-500 hidden sm:block">{userEmail ?? ""}</p>
+          </div>
+        </div>
+
+        {/* Right: Logout */}
+        <div className="flex items-center gap-4">
+          {userEmail && (
+            <button
+              onClick={onLogout}
+              className="text-sm text-gray-600 bg-gray-100 px-3 py-1.5 rounded hover:bg-gray-200 transition"
+            >
+              Logout
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <nav className="max-w-4xl mx-auto px-4">
+        <ul className="flex border-b border-gray-200">
+          {tabs.map((tab) => {
+            const isActive = pathname.startsWith(tab.href);
+            return (
+              <li key={tab.name}>
+                <Link
+                  href={tab.href}
+                  className={cn(
+                    "inline-block px-4 py-2 text-sm font-medium transition-all",
+                    isActive
+                      ? "text-emerald-600 border-b-2 border-emerald-500"
+                      : "text-gray-500 hover:text-gray-700"
+                  )}
+                >
+                  {tab.name}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </header>
+  );
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}


### PR DESCRIPTION
## Summary
- replace old header markup with new `Header` component
- create a utility `cn` function
- hook header into the layout

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba3f2fa8c833098b38592b9bfe938