### PR TITLE
Integrate creation with scheduling

### DIFF
--- a/app/tournaments/page.tsx
+++ b/app/tournaments/page.tsx
@@ -89,18 +89,6 @@ export default function TournamentsPage() {
     form.reset();
   };
 
-  const createEmptyTournament = async () => {
-    if (!user) return;
-    const name = window.prompt("Tournament name") || "";
-    if (!name) return;
-    const insertedId = await createTournamentRecord(name);
-    if (insertedId) {
-      setTournaments((prev) => [
-        ...prev,
-        { id: insertedId, name, teams: [] },
-      ]);
-    }
-  };
 
   const deleteTournament = async (id: number) => {
     if (!user) return;
@@ -193,7 +181,6 @@ export default function TournamentsPage() {
       tournaments={tournaments}
       teams={teams}
       onSchedule={handleSchedule}
-      onCreate={createEmptyTournament}
       onRun={(id) => router.push(`/run/${id}`)}
       onView={(id) => router.push(`/tournaments/${id}`)}
       onDelete={deleteTournament}

--- a/components/TournamentsView.tsx
+++ b/components/TournamentsView.tsx
@@ -15,7 +15,6 @@ interface Props {
   tournaments: Tournament[];
   teams: Team[];
   onSchedule: React.FormEventHandler<HTMLFormElement>;
-  onCreate: React.MouseEventHandler<HTMLButtonElement>;
   onRun: (id: number) => void;
   onView: (id: number) => void;
   onDelete: (id: number) => void;
@@ -25,7 +24,6 @@ export default function TournamentsView({
   tournaments,
   teams,
   onSchedule,
-  onCreate,
   onRun,
   onView,
   onDelete,
@@ -70,10 +68,7 @@ export default function TournamentsView({
 
       {/* Tournaments List */}
       <section className="space-y-4">
-        <div className="flex justify-between items-center">
-          <h2 className="text-xl font-semibold">Tournaments</h2>
-          <Button variant="outline" onClick={onCreate}>Create New Tournament</Button>
-        </div>
+        <h2 className="text-xl font-semibold">Tournaments</h2>
 
         {tournaments.map((tournament) => (
           <div


### PR DESCRIPTION
## Summary
- remove the separate `Create New Tournament` button
- adjust `TournamentsView` props accordingly

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb142da4c833097fb7cafeea4df3f