### PR TITLE
Integrate creation with scheduling

### DIFF
--- a/app/tournaments/page.tsx
+++ b/app/tournaments/page.tsx
@@ -5,16 +5,16 @@ import { supabase } from "../../lib/supabaseBrowser";
 import { useRouter } from "next/navigation";
 
 interface Team {
-  id: number;
+  id: string;
   name: string;
 }
 
 interface TournamentTeam {
-  id: number;
+  id: string;
 }
 
 interface Tournament {
-  id: number;
+  id: string;
   name: string;
   teams: TournamentTeam[];
 }
@@ -24,6 +24,7 @@ export default function TournamentsPage() {
   const [user, setUser] = useState<any>(null);
   const [teams, setTeams] = useState<Team[]>([]);
   const [tournaments, setTournaments] = useState<Tournament[]>([]);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -68,41 +69,33 @@ export default function TournamentsPage() {
     const teamInputs = Array.from(
       form.querySelectorAll<HTMLInputElement>("input[name='teamSelection']:checked")
     );
-    const ids = teamInputs.map((inp) => Number(inp.value));
+    const ids = teamInputs.map((inp) => inp.value);
     if (!name || ids.length === 0) return;
 
-    const insertedId = await createTournamentRecord(name);
-    if (insertedId) {
-      await supabase
-        .from("teams")
-        .update({ tournament_id: insertedId })
-        .in("id", ids)
-        .eq("user_id", user.id);
+    setLoading(true);
+    try {
+      const insertedId = await createTournamentRecord(name);
+      if (insertedId) {
+        await supabase
+          .from("teams")
+          .update({ tournament_id: insertedId })
+          .in("id", ids)
+          .eq("user_id", user.id);
 
-      setTournaments((prev) => [
-        ...prev,
-        { id: insertedId, name, teams: ids.map((id) => ({ id })) },
-      ]);
-      await generateSchedule(insertedId);
-    }
-
-    form.reset();
-  };
-
-  const createEmptyTournament = async () => {
-    if (!user) return;
-    const name = window.prompt("Tournament name") || "";
-    if (!name) return;
-    const insertedId = await createTournamentRecord(name);
-    if (insertedId) {
-      setTournaments((prev) => [
-        ...prev,
-        { id: insertedId, name, teams: [] },
-      ]);
+        setTournaments((prev) => [
+          ...prev,
+          { id: insertedId, name, teams: ids.map((id) => ({ id })) },
+        ]);
+        await generateSchedule(insertedId);
+      }
+    } finally {
+      setLoading(false);
+      form.reset();
     }
   };
 
-  const deleteTournament = async (id: number) => {
+
+  const deleteTournament = async (id: string) => {
     if (!user) return;
     if (!confirm("Delete this tournament?")) return;
     await supabase
@@ -123,7 +116,7 @@ export default function TournamentsPage() {
     setTournaments((prev) => prev.filter((t) => t.id !== id));
   };
 
-  async function generateSchedule(id: number) {
+  async function generateSchedule(id: string) {
     const { data: userData } = await supabase.auth.getUser();
     const currentUser = userData.user;
     if (!currentUser) {
@@ -193,10 +186,10 @@ export default function TournamentsPage() {
       tournaments={tournaments}
       teams={teams}
       onSchedule={handleSchedule}
-      onCreate={createEmptyTournament}
       onRun={(id) => router.push(`/run/${id}`)}
       onView={(id) => router.push(`/tournaments/${id}`)}
       onDelete={deleteTournament}
+      loading={loading}
     />
   );
 }

--- a/components/TournamentsView.tsx
+++ b/components/TournamentsView.tsx
@@ -1,37 +1,42 @@
 import { Button } from "@/components/ui/button";
 
 interface Team {
-  id: number;
+  id: string;
   name: string;
 }
 
 interface Tournament {
-  id: number;
+  id: string;
   name: string;
-  teams: { id: number }[];
+  teams: { id: string }[];
 }
 
 interface Props {
   tournaments: Tournament[];
   teams: Team[];
   onSchedule: React.FormEventHandler<HTMLFormElement>;
-  onCreate: React.MouseEventHandler<HTMLButtonElement>;
-  onRun: (id: number) => void;
-  onView: (id: number) => void;
-  onDelete: (id: number) => void;
+  onRun: (id: string) => void;
+  onView: (id: string) => void;
+  onDelete: (id: string) => void;
+  loading?: boolean;
 }
 
 export default function TournamentsView({
   tournaments,
   teams,
   onSchedule,
-  onCreate,
   onRun,
   onView,
   onDelete,
+  loading,
 }: Props) {
   return (
-    <div className="max-w-3xl mx-auto p-6 space-y-8">
+    <div className="relative max-w-3xl mx-auto p-6 space-y-8">
+      {loading && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+          <img src="/babyfoot.svg" alt="loading" className="w-20 h-20 animate-spin" />
+        </div>
+      )}
       {/* Tournament Setup */}
       <section className="bg-white border border-gray-200 rounded-xl shadow-sm p-5 space-y-4">
         <h2 className="text-xl font-semibold">Tournament Setup</h2>
@@ -70,10 +75,7 @@ export default function TournamentsView({
 
       {/* Tournaments List */}
       <section className="space-y-4">
-        <div className="flex justify-between items-center">
-          <h2 className="text-xl font-semibold">Tournaments</h2>
-          <Button variant="outline" onClick={onCreate}>Create New Tournament</Button>
-        </div>
+        <h2 className="text-xl font-semibold">Tournaments</h2>
 
         {tournaments.map((tournament) => (
           <div


### PR DESCRIPTION
## Summary
- remove the separate `Create New Tournament` button
- adjust `TournamentsView` props accordingly
- fix team id handling when scheduling tournaments
- show rotating babyfoot overlay while waiting for AI

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb142da4c833097fb7cafeea4df3f