### PR TITLE
Handle bye advancement

### DIFF
--- a/app/api/best-schedule/route.ts
+++ b/app/api/best-schedule/route.ts
@@ -27,7 +27,10 @@ export async function POST(req: NextRequest) {
   }
 
   const prompt =
-    'You are an expert tournament organiser. Given a list of teams with their ids and names, create a schedule that minimises the number of rounds needed to determine a winner. Respond only with JSON in the format {"strategy":"string","matches":[{"round":1,"teamA":id,"teamB":id}]}.';
+    'You are an expert tournament organiser. Given a list of teams with their ids and names, create a knockout style schedule that includes **every** team. ' +
+    'If the number of teams is not a power of two, use play‑in games or byes so that all teams get a chance to compete. ' +
+    'For any match involving a bye, use `null` for the missing team\'s id and assume the opponent automatically advances. ' +
+    'Respond only with JSON in the format {"strategy":"string","matches":[{"round":1,"teamA":id,"teamB":id}]}.';
 
   debug.push("Key retrieved, contacting OpenAI...");
   try {

--- a/app/run/[id]/page.tsx
+++ b/app/run/[id]/page.tsx
@@ -107,7 +107,9 @@ export default function TournamentRunPage() {
   }, [id]);
 
   const teamName = (tid: number | null | undefined) =>
-    teams.find((t) => t.id === tid)?.name || "Unknown team";
+    tid === null || tid === undefined
+      ? "BYE"
+      : teams.find((t) => t.id === tid)?.name || "Unknown team";
 
   const triggerFireworks = () => {
     const container = document.createElement("div");
@@ -142,18 +144,42 @@ export default function TournamentRunPage() {
       return;
     }
 
-    const pairs: { team_a: number; team_b: number }[] = [];
-    for (let i = 0; i < winners.length; i += 2) {
-      if (winners[i + 1] !== undefined) {
-        pairs.push({ team_a: winners[i], team_b: winners[i + 1] });
+    const byeCounts: Record<number, number> = {};
+    matches.forEach((m) => {
+      if ((m.team_a && !m.team_b) || (m.team_b && !m.team_a)) {
+        const id = (m.team_a || m.team_b) as number;
+        byeCounts[id] = (byeCounts[id] || 0) + 1;
+      }
+    });
+
+    const pairings: { team_a: number; team_b: number | null; winner?: number }[] = [];
+    const ordered = [...winners];
+
+    if (ordered.length % 2 === 1) {
+      let byeTeam = ordered[0];
+      for (const id of ordered) {
+        const count = byeCounts[id] || 0;
+        if (count < (byeCounts[byeTeam] || 0)) {
+          byeTeam = id;
+        }
+      }
+      ordered.splice(ordered.indexOf(byeTeam), 1);
+      pairings.push({ team_a: byeTeam, team_b: null, winner: byeTeam });
+    }
+
+    for (let i = 0; i < ordered.length; i += 2) {
+      if (ordered[i + 1] !== undefined) {
+        pairings.push({ team_a: ordered[i], team_b: ordered[i + 1] });
       }
     }
 
     const nextRoundNum = currentRound + 1;
-    if (pairs.length) {
+    if (pairings.length) {
       await supabase.from("matches").insert(
-        pairs.map((p) => ({
-          ...p,
+        pairings.map((p) => ({
+          team_a: p.team_a,
+          team_b: p.team_b,
+          winner: p.winner,
           phase: `round${nextRoundNum}`,
           scheduled_at: null,
           tournament_id: id,

--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -54,7 +54,9 @@ export default function TournamentViewPage() {
   }, [id]);
 
   const teamName = (tid: number | null | undefined) =>
-    teams.find((t) => t.id === tid)?.name || "Unknown team";
+    tid === null || tid === undefined
+      ? "BYE"
+      : teams.find((t) => t.id === tid)?.name || "Unknown team";
 
   const phases = Array.from(new Set(matches.map((m) => m.phase))).sort(
     (a, b) =>

--- a/app/tournaments/page.tsx
+++ b/app/tournaments/page.tsx
@@ -135,7 +135,7 @@ export default function TournamentsPage() {
     }
 
     const isPower = (n: number) => (n & (n - 1)) === 0 && n !== 0;
-    let schedule: { matches: { round: number; teamA: number; teamB: number }[] } & {
+    let schedule: { matches: { round: number; teamA: number | null; teamB: number | null; winner?: number | null }[] } & {
       debug?: string[];
     } = { matches: [] };
 
@@ -156,6 +156,16 @@ export default function TournamentsPage() {
       const json = await res.json();
       if (res.ok) {
         schedule = json;
+        schedule.matches = schedule.matches
+          .map((m: any) => {
+            const teamA = m.teamA === "bye" || m.teamA === "null" ? null : m.teamA;
+            const teamB = m.teamB === "bye" || m.teamB === "null" ? null : m.teamB;
+            let winner = null as number | null;
+            if (teamA && !teamB) winner = teamA;
+            if (teamB && !teamA) winner = teamB;
+            return { round: m.round, teamA, teamB, winner };
+          })
+          .filter((m: any) => m.round === 1);
       } else {
         alert(json.error || "AI schedule failed");
       }
@@ -172,6 +182,7 @@ export default function TournamentsPage() {
         schedule.matches.map((m) => ({
           team_a: m.teamA,
           team_b: m.teamB,
+          winner: m.winner,
           phase: `round${m.round}`,
           scheduled_at: null,
           tournament_id: id,


### PR DESCRIPTION
## Summary
- add fairness when pairing next rounds so bye winners continue
- only keep first round of AI schedule

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb93596b88330b86b7a6da872310b