### PR TITLE
Use tournament_teams table

### DIFF
--- a/app/run/[id]/page.tsx
+++ b/app/run/[id]/page.tsx
@@ -57,18 +57,23 @@ export default function TournamentRunPage() {
           .eq("user_id", currentUser.id);
 
         const { data: teamData } = await supabase
-          .from("teams")
-          .select("id, name")
-          .eq("user_id", currentUser.id)
-          .eq("tournament_id", id);
+          .from("tournament_teams")
+          .select("team_id, teams(id, name, user_id)")
+          .eq("tournament_id", id)
+          .eq("teams.user_id", currentUser.id);
+
+        const teamsConverted = (teamData || []).map((tt: any) => ({
+          id: tt.team_id,
+          name: tt.teams?.name ?? "",
+        }));
 
         if (!matchData || matchData.length === 0) {
           const pairs: { team_a: number; team_b: number }[] = [];
-          for (let i = 0; i < (teamData || []).length; i += 2) {
-            if (teamData && teamData[i + 1]) {
+          for (let i = 0; i < teamsConverted.length; i += 2) {
+            if (teamsConverted[i + 1]) {
               pairs.push({
-                team_a: teamData[i].id,
-                team_b: teamData[i + 1].id,
+                team_a: teamsConverted[i].id,
+                team_b: teamsConverted[i + 1].id,
               });
             }
           }
@@ -94,7 +99,7 @@ export default function TournamentRunPage() {
         }
 
         setMatches(matchData || []);
-        setTeams(teamData || []);
+        setTeams(teamsConverted);
 
         const initial: Record<number, { a: number; b: number }> = {};
         (matchData || []).forEach((m) => {

--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -39,10 +39,15 @@ export default function TournamentViewPage() {
       setTournament(t);
 
       const { data: teamData } = await supabase
-        .from("teams")
-        .select("id, name")
+        .from("tournament_teams")
+        .select("team_id, teams(id, name)")
         .eq("tournament_id", id);
-      setTeams(teamData || []);
+      setTeams(
+        (teamData || []).map((tt: any) => ({
+          id: tt.team_id,
+          name: tt.teams?.name ?? "",
+        }))
+      );
 
       const { data: matchData } = await supabase
         .from("matches")

--- a/app/tournaments/setup/page.tsx
+++ b/app/tournaments/setup/page.tsx
@@ -50,11 +50,9 @@ export default function TournamentSetupPage() {
       .single();
 
     if (inserted?.id) {
-      await supabase
-        .from("teams")
-        .update({ tournament_id: inserted.id })
-        .in("id", selected)
-        .eq("user_id", user.id);
+      await supabase.from("tournament_teams").insert(
+        selected.map((teamId) => ({ tournament_id: inserted.id, team_id: teamId }))
+      );
     }
 
     setName("");


### PR DESCRIPTION
## Summary
- query tournament teams via new `tournament_teams` join table
- store selected teams in `tournament_teams` when creating a tournament
- remove old `tournament_id` updates during tournament delete
- update tournament details and run pages to read teams using the join table

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cb10b2c508330bbf9520d175d51e3