### PR TITLE
Add Settings tab with data purge option

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { useEffect, useState } from "react";
+import { supabase } from "../../lib/supabaseBrowser";
+import { Button } from "../../components/ui/button";
+
+export default function SettingsPage() {
+  const [user, setUser] = useState<any>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => setUser(data.user));
+  }, []);
+
+  const deleteAllData = async () => {
+    if (!user) return;
+    if (
+      !confirm(
+        "Delete all players, teams and tournaments? This cannot be undone."
+      )
+    )
+      return;
+
+    await supabase.from("team_players").delete().eq("user_id", user.id);
+    await supabase.from("matches").delete().eq("user_id", user.id);
+    await supabase.from("tournament_teams").delete().eq("user_id", user.id);
+    await supabase.from("tournaments").delete().eq("user_id", user.id);
+    await supabase.from("teams").delete().eq("user_id", user.id);
+    await supabase.from("players").delete().eq("user_id", user.id);
+    alert("All data deleted.");
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-6">
+      <h2 className="text-2xl font-semibold">Settings</h2>
+
+      <section className="bg-red-50 border border-red-300 rounded-xl p-4 space-y-4">
+        <h3 className="text-red-700 font-semibold">Danger Zone</h3>
+        <p className="text-sm text-red-700">
+          This will permanently remove all your players, teams and tournaments.
+        </p>
+        <Button variant="destructive" onClick={deleteAllData}>
+          Delete My Data
+        </Button>
+      </section>
+    </div>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -10,6 +10,7 @@ const tabs = [
   { name: "Players", href: "/players" },
   { name: "Teams", href: "/teams" },
   { name: "Tournaments", href: "/tournaments" },
+  { name: "Settings", href: "/settings" },
 ];
 
 export default function Header() {

--- a/components/NavButtons.tsx
+++ b/components/NavButtons.tsx
@@ -8,6 +8,7 @@ export default function NavButtons() {
     { href: "/players", label: "Players" },
     { href: "/teams", label: "Teams" },
     { href: "/tournaments", label: "Tournaments" },
+    { href: "/settings", label: "Settings" },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- add a `/settings` page
- show a Danger Zone to delete all user data
- expose Settings in header navigation and NavButtons

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cb8efdd5883308eb055309fb7bf51