### PR TITLE
Add CSV player import to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,19 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Importing Players from CSV
+
+On the Settings page you can bulk add players by uploading a CSV file. Each line
+of the file should contain three values: `name`, `offense`, and `defense`.
+Example:
+
+```
+name,offense,defense
+Alice,7,6
+Bob,5,8
+```
+
+The first row can optionally be a header and will be ignored. Rows must include
+all three values. After selecting your file, click **Import Players** to create
+the records in Supabase.

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -8,9 +8,17 @@ interface ButtonProps {
   onClick?: MouseEventHandler<HTMLButtonElement>;
   variant?: BuiltInVariant | string;
   type?: "button" | "submit" | "reset";
+  disabled?: boolean;
 }
 
-export function Button({ children, className = "", onClick, variant = "default", type = "button" }: ButtonProps) {
+export function Button({
+  children,
+  className = "",
+  onClick,
+  variant = "default",
+  type = "button",
+  disabled = false,
+}: ButtonProps) {
   const base =
     "inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-lg transition";
   const variants = {
@@ -24,11 +32,14 @@ export function Button({ children, className = "", onClick, variant = "default",
       ? (variants as Record<BuiltInVariant, string>)[variant as BuiltInVariant]
       : variant;
 
+  const disabledClass = disabled ? "opacity-50 cursor-not-allowed" : "";
+
   return (
     <button
       type={type}
-      className={`${base} ${variantClass} ${className}`.trim()}
+      className={`${base} ${variantClass} ${disabledClass} ${className}`.trim()}
       onClick={onClick}
+      disabled={disabled}
     >
       {children}
     </button>


### PR DESCRIPTION
## Summary
- add simple CSV import to Settings page
- parse CSV data and insert new players
- document expected CSV format for users

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbcc6bc7c83308993703320b6fbbf