### PR TITLE
Add SelectableTagGroup for modern selection UI

### DIFF
--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -58,17 +58,8 @@ export default function TeamsPage() {
   }, []);
 
 
-  const addTeam = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const addTeam = async (name: string, memberIds: number[]) => {
     if (!user) return;
-
-    const form = e.currentTarget;
-    const name = (form.elements.namedItem("teamName") as HTMLInputElement).value;
-    const memberInputs = Array.from(
-      form.querySelectorAll<HTMLInputElement>("input[name='members']:checked"),
-    );
-    const memberIds = memberInputs.map((inp) => Number(inp.value));
-
     if (!name || memberIds.length !== 2) return;
 
     const { data: inserted } = await supabase
@@ -104,7 +95,6 @@ export default function TeamsPage() {
     }));
 
     setTeams(combined);
-    form.reset();
   };
 
   const editTeam = async (team: TeamRow) => {

--- a/app/tournaments/page.tsx
+++ b/app/tournaments/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { FormEvent, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import TournamentsView from "../../components/TournamentsView";
 import { supabase } from "../../lib/supabaseBrowser";
 import { useRouter } from "next/navigation";
@@ -62,15 +62,8 @@ export default function TournamentsPage() {
     return inserted?.id;
   };
 
-  const handleSchedule = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const handleSchedule = async (name: string, ids: string[]) => {
     if (!user) return;
-    const form = e.currentTarget;
-    const name = (form.elements.namedItem("tournamentName") as HTMLInputElement).value;
-    const teamInputs = Array.from(
-      form.querySelectorAll<HTMLInputElement>("input[name='teamSelection']:checked")
-    );
-    const ids = teamInputs.map((inp) => inp.value);
     if (!name || ids.length === 0) return;
 
     setLoading(true);
@@ -89,7 +82,6 @@ export default function TournamentsPage() {
       }
     } finally {
       setLoading(false);
-      form.reset();
     }
   };
 

--- a/components/SelectableTagGroup.tsx
+++ b/components/SelectableTagGroup.tsx
@@ -1,0 +1,47 @@
+"use client";
+import React from "react";
+
+interface BaseItem {
+  id: number | string;
+  [key: string]: any;
+}
+
+interface SelectableTagGroupProps<T extends BaseItem> {
+  items: T[];
+  selectedIds: Array<T["id"]>;
+  onToggle: (id: T["id"]) => void;
+  label?: string;
+  getLabel?: (item: T) => string;
+  maxHeight?: string;
+}
+
+export default function SelectableTagGroup<T extends BaseItem>({
+  items,
+  selectedIds,
+  onToggle,
+  label = "Select items",
+  getLabel = (item) => (item as any).name,
+  maxHeight = "max-h-40",
+}: SelectableTagGroupProps<T>) {
+  return (
+    <div className="space-y-2">
+      <label className="font-medium text-sm">{label}</label>
+      <div
+        className={`flex flex-wrap gap-2 overflow-y-auto border border-gray-200 rounded-lg p-3 bg-white ${maxHeight}`}
+      >
+        {items.map((item) => {
+          const isSelected = selectedIds.includes(item.id);
+          return (
+            <label
+              key={item.id}
+              className={`px-3 py-1 rounded-full border text-sm cursor-pointer transition ${isSelected ? "bg-emerald-100 text-emerald-700 border-emerald-300" : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"}`}
+              onClick={() => onToggle(item.id)}
+            >
+              {getLabel(item)}
+            </label>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/TeamsView.tsx
+++ b/components/TeamsView.tsx
@@ -1,4 +1,7 @@
+"use client";
+import { useState, FormEvent } from "react";
 import { Button } from "@/components/ui/button";
+import SelectableTagGroup from "./SelectableTagGroup";
 
 export interface Player {
   id: number;
@@ -16,7 +19,7 @@ export interface Team {
 interface Props {
   teams: Team[];
   players: Player[];
-  onAdd: React.FormEventHandler<HTMLFormElement>;
+  onAdd: (name: string, memberIds: number[]) => void | Promise<void>;
   onEdit: (team: Team) => void;
   onDelete: (id: number) => void;
   onGenerateBalanced: () => void;
@@ -40,6 +43,23 @@ export default function TeamsView({
   onDelete,
   onGenerateBalanced,
 }: Props) {
+  const [selectedPlayers, setSelectedPlayers] = useState<number[]>([]);
+
+  const togglePlayer = (id: number) => {
+    setSelectedPlayers((prev) =>
+      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id]
+    );
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const name = (form.elements.namedItem("teamName") as HTMLInputElement).value;
+    onAdd(name, selectedPlayers);
+    setSelectedPlayers([]);
+    form.reset();
+  };
+
   const playerName = (id: number) => players.find((p) => p.id === id)?.name || "";
 
   return (
@@ -54,7 +74,7 @@ export default function TeamsView({
 
       {/* Add New Team */}
       <form
-        onSubmit={onAdd}
+        onSubmit={handleSubmit}
         className="bg-white border border-gray-200 rounded-xl shadow-sm p-4 space-y-4"
       >
         <div className="grid sm:grid-cols-2 gap-4">
@@ -65,20 +85,14 @@ export default function TeamsView({
             className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
           />
 
-          {/* Player checkboxes */}
-          <div className="flex flex-wrap gap-2 max-h-32 overflow-y-auto">
-            {players.map((player) => (
-              <label key={player.id} className="text-sm flex items-center gap-1">
-                <input
-                  type="checkbox"
-                  name="members"
-                  value={player.id}
-                  className="rounded text-emerald-600"
-                />
-                {player.name}
-              </label>
-            ))}
-          </div>
+          <SelectableTagGroup
+            items={players}
+            selectedIds={selectedPlayers}
+            onToggle={togglePlayer}
+            label="Select Players"
+            getLabel={(p) => p.name}
+            maxHeight="max-h-32"
+          />
         </div>
 
         <Button type="submit" className="mt-2">

--- a/components/TournamentsView.tsx
+++ b/components/TournamentsView.tsx
@@ -1,4 +1,7 @@
+"use client";
+import { useState, FormEvent } from "react";
 import { Button } from "@/components/ui/button";
+import SelectableTagGroup from "./SelectableTagGroup";
 
 interface Team {
   id: string;
@@ -14,7 +17,7 @@ interface Tournament {
 interface Props {
   tournaments: Tournament[];
   teams: Team[];
-  onSchedule: React.FormEventHandler<HTMLFormElement>;
+  onSchedule: (name: string, teamIds: string[]) => void | Promise<void>;
   onRun: (id: string) => void;
   onView: (id: string) => void;
   onDelete: (id: string) => void;
@@ -30,6 +33,22 @@ export default function TournamentsView({
   onDelete,
   loading,
 }: Props) {
+  const [selectedTeams, setSelectedTeams] = useState<string[]>([]);
+
+  const toggleTeam = (id: string) => {
+    setSelectedTeams((prev) =>
+      prev.includes(id) ? prev.filter((t) => t !== id) : [...prev, id]
+    );
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const name = (form.elements.namedItem("tournamentName") as HTMLInputElement).value;
+    onSchedule(name, selectedTeams);
+    setSelectedTeams([]);
+    form.reset();
+  };
   return (
     <div className="relative max-w-3xl mx-auto p-6 space-y-8">
       {loading && (
@@ -41,7 +60,7 @@ export default function TournamentsView({
       <section className="bg-white border border-gray-200 rounded-xl shadow-sm p-5 space-y-4">
         <h2 className="text-xl font-semibold">Tournament Setup</h2>
 
-        <form onSubmit={onSchedule} className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-4">
           <input
             type="text"
             name="tournamentName"
@@ -50,22 +69,14 @@ export default function TournamentsView({
             className="w-full px-4 py-2 border border-gray-300 rounded-md text-sm"
           />
 
-          <div>
-            <label className="block font-medium mb-1 text-sm">Select Teams</label>
-            <div className="flex flex-wrap gap-3 max-h-32 overflow-y-auto">
-              {teams.map((team) => (
-                <label key={team.id} className="flex items-center gap-1 text-sm">
-                  <input
-                    type="checkbox"
-                    name="teamSelection"
-                    value={team.id}
-                    className="text-emerald-600 rounded"
-                  />
-                  {team.name}
-                </label>
-              ))}
-            </div>
-          </div>
+          <SelectableTagGroup
+            label="Select Teams"
+            items={teams}
+            selectedIds={selectedTeams}
+            onToggle={toggleTeam}
+            getLabel={(t) => t.name}
+            maxHeight="max-h-32"
+          />
 
           <Button type="submit" className="mt-2 bg-emerald-600 hover:bg-emerald-700">
             AI Schedule


### PR DESCRIPTION
## Summary
- implement reusable `SelectableTagGroup` component
- update team creation form to use selectable tags
- update tournament scheduling form to use selectable tags
- adapt pages to new callback signatures

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cd855d9e483308d896407f910e500