### PR TITLE
Improve teams and winner experience

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -25,8 +25,8 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
-/* simple fireworks animation used when a tournament winner is decided */
-.fireworks-container {
+/* confetti animation used when a tournament winner is decided */
+.confetti-container {
   position: fixed;
   inset: 0;
   pointer-events: none;
@@ -34,19 +34,19 @@ body {
   z-index: 50;
 }
 
-.firework {
+.confetti {
   position: absolute;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
+  top: -10px;
+  width: 8px;
+  height: 12px;
+  opacity: 0.8;
   background: currentColor;
-  /* extend the animation so the fireworks are visible for longer */
-  animation: firework 3s ease-out forwards;
+  animation: confetti-fall 5s linear forwards;
 }
 
-@keyframes firework {
+@keyframes confetti-fall {
   to {
-    transform: translate3d(var(--x), var(--y), 0) scale(0);
+    transform: translateY(100vh) rotate(360deg);
     opacity: 0;
   }
 }

--- a/app/run/[id]/page.tsx
+++ b/app/run/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState, useRef } from "react";
+import { Button } from "@/components/ui/button";
 import { useParams } from "next/navigation";
 import { supabase } from "../../../lib/supabaseBrowser";
 
@@ -116,22 +117,19 @@ export default function TournamentRunPage() {
       ? "BYE"
       : teams.find((t) => t.id === tid)?.name || "Unknown team";
 
-  const triggerFireworks = () => {
+  const triggerConfetti = () => {
     const container = document.createElement("div");
-    container.className = "fireworks-container";
-    for (let i = 0; i < 20; i++) {
+    container.className = "confetti-container";
+    for (let i = 0; i < 100; i++) {
       const el = document.createElement("div");
-      el.className = "firework";
-      el.style.left = `${50}%`;
-      el.style.top = `${50}%`;
-      el.style.setProperty("--x", `${(Math.random() - 0.5) * 400}px`);
-      el.style.setProperty("--y", `${(Math.random() - 0.5) * 400}px`);
-      el.style.color = `hsl(${Math.random() * 360},100%,50%)`;
+      el.className = "confetti";
+      el.style.left = `${Math.random() * 100}%`;
+      el.style.backgroundColor = `hsl(${Math.random() * 360},100%,50%)`;
+      el.style.animationDelay = `${Math.random() * 0.5}s`;
       container.appendChild(el);
     }
     document.body.appendChild(container);
-    // keep the fireworks visible for a little longer so users can enjoy them
-    setTimeout(() => container.remove(), 3000);
+    setTimeout(() => container.remove(), 5000);
   };
 
   const nextRound = async () => {
@@ -145,7 +143,7 @@ export default function TournamentRunPage() {
     if (winners.length !== currentMatches.length) return;
 
     if (winners.length === 1) {
-      triggerFireworks();
+      triggerConfetti();
       return;
     }
 
@@ -249,7 +247,7 @@ export default function TournamentRunPage() {
       (m) => parseInt(m.phase.replace(/\D/g, "")) === maxRound
     );
     if (finalMatches.length === 1 && finalMatches[0].winner) {
-      triggerFireworks();
+      triggerConfetti();
       setCelebrated(true);
     }
   }, [matches, celebrated]);
@@ -321,9 +319,9 @@ export default function TournamentRunPage() {
         ))}
       </div>
       {canAdvance && (
-        <button className="border bg-gray-200 px-2" onClick={nextRound}>
+        <Button className="bg-blue-500 hover:bg-blue-600" onClick={nextRound}>
           Next Round
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -21,6 +21,7 @@ export default function TeamsPage() {
   const [user, setUser] = useState<any>(null);
   const [players, setPlayers] = useState<Player[]>([]);
   const [teams, setTeams] = useState<TeamRow[]>([]);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -185,12 +186,16 @@ export default function TeamsPage() {
 
   const generateBalancedTeams = async () => {
     if (!user) return;
+    setLoading(true);
     const res = await fetch("/api/balanced-teams", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ players }),
     });
-    if (!res.ok) return;
+    if (!res.ok) {
+      setLoading(false);
+      return;
+    }
     const { teams: newTeams } = await res.json();
     for (const t of newTeams || []) {
       const { data: inserted } = await supabase
@@ -225,6 +230,7 @@ export default function TeamsPage() {
         .map((tp) => tp.player_id),
     }));
     setTeams(combined);
+    setLoading(false);
   };
 
   return (
@@ -235,6 +241,7 @@ export default function TeamsPage() {
       onEdit={editTeam}
       onDelete={deleteTeam}
       onGenerateBalanced={generateBalancedTeams}
+      loading={loading}
     />
   );
 }

--- a/components/TeamsView.tsx
+++ b/components/TeamsView.tsx
@@ -23,6 +23,7 @@ interface Props {
   onEdit: (team: Team) => void;
   onDelete: (id: number) => void;
   onGenerateBalanced: () => void;
+  loading?: boolean;
 }
 
 function teamOffense(ids: number[], players: Player[]) {
@@ -42,6 +43,7 @@ export default function TeamsView({
   onEdit,
   onDelete,
   onGenerateBalanced,
+  loading,
 }: Props) {
   const [selectedPlayers, setSelectedPlayers] = useState<number[]>([]);
 
@@ -63,12 +65,17 @@ export default function TeamsView({
   const playerName = (id: number) => players.find((p) => p.id === id)?.name || "";
 
   return (
-    <div className="max-w-3xl mx-auto p-6 space-y-6">
+    <div className="relative max-w-3xl mx-auto p-6 space-y-6">
+      {loading && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+          <img src="/babyfoot.svg" alt="loading" className="w-20 h-20 animate-spin" />
+        </div>
+      )}
       {/* Header */}
       <div className="flex justify-between items-center">
         <h2 className="text-2xl font-semibold">Teams</h2>
         <Button variant="outline" onClick={onGenerateBalanced}>
-          Balanced Teams
+          AI balanced teams
         </Button>
       </div>
 


### PR DESCRIPTION
## Summary
- rename the Balanced Teams button to **AI balanced teams** and show loader while generating
- update Teams page logic to handle loading state
- restyle the Next Round button
- replace fireworks with a confetti effect

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cdcb59f9c83308ac4949cd5c8e496