### PR TITLE
Add public tournament view

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,6 +26,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <LoginOverlay>
           <Header />

--- a/app/tournaments/[id]/public/page.tsx
+++ b/app/tournaments/[id]/public/page.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { supabase } from '@/lib/supabaseBrowser';
+import QRCode from '@/components/QRCode';
+
+interface Team {
+  id: number;
+  name: string;
+}
+
+interface Match {
+  id: number;
+  team_a: number | null;
+  team_b: number | null;
+  result: string | null;
+  team1_name?: string;
+  team2_name?: string;
+}
+
+export default function PublicTournamentView() {
+  const { id } = useParams<{ id: string }>();
+  const [tournament, setTournament] = useState<any>(null);
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [matches, setMatches] = useState<Match[]>([]);
+  const [shareUrl, setShareUrl] = useState('');
+
+  useEffect(() => {
+    setShareUrl(window.location.href);
+  }, []);
+
+  useEffect(() => {
+    const loadData = async () => {
+      const { data: t } = await supabase
+        .from('tournaments')
+        .select('*')
+        .eq('id', id)
+        .single();
+      setTournament(t);
+
+      const { data: teamData } = await supabase
+        .from('tournament_teams')
+        .select('team_id, teams(id, name)')
+        .eq('tournament_id', id);
+      setTeams(
+        (teamData || []).map((tt: any) => ({
+          id: tt.team_id,
+          name: tt.teams?.name ?? ''
+        }))
+      );
+
+      const { data: matchData } = await supabase
+        .from('matches')
+        .select('*')
+        .eq('tournament_id', id)
+        .order('created_at', { ascending: true });
+      setMatches(matchData || []);
+    };
+
+    if (id) loadData();
+  }, [id]);
+
+  if (!tournament) return <div className="p-4">Loading...</div>;
+
+  const teamName = (tid: number | null) =>
+    tid === null ? 'BYE' : teams.find((t) => t.id === tid)?.name || 'Unknown';
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-2">{tournament.name}</h1>
+      <p className="mb-4 text-gray-600">Tournament in progress</p>
+
+      <h2 className="text-xl font-semibold mt-6">Teams</h2>
+      <ul className="list-disc list-inside">
+        {teams.map((team) => (
+          <li key={team.id}>{team.name}</li>
+        ))}
+      </ul>
+
+      <h2 className="text-xl font-semibold mt-6">Matches</h2>
+      <ul className="mt-2">
+        {matches.map((match, index) => (
+          <li key={match.id} className="border-b py-2">
+            Match {index + 1}: {teamName(match.team_a)} vs {teamName(match.team_b)} —{' '}
+            <strong>{match.result || 'TBD'}</strong>
+          </li>
+        ))}
+      </ul>
+
+      <button
+        onClick={() =>
+          navigator.share?.({
+            title: tournament.name,
+            url: shareUrl,
+            text: 'Follow the tournament live!'
+          })
+        }
+        className="mt-6 px-4 py-2 bg-blue-600 text-white rounded-lg"
+      >
+        Share with Participants
+      </button>
+
+      <div className="mt-6 flex justify-center">
+        <QRCode value={shareUrl} />
+      </div>
+    </div>
+  );
+}

--- a/components/LoginOverlay.tsx
+++ b/components/LoginOverlay.tsx
@@ -1,8 +1,10 @@
 "use client";
 import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 import { supabase } from "../lib/supabaseBrowser";
 
 export default function LoginOverlay({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
   const [user, setUser] = useState<any>(undefined);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -12,6 +14,10 @@ export default function LoginOverlay({ children }: { children: React.ReactNode }
       "login"
     );
   const [message, setMessage] = useState("");
+
+  if (pathname.includes("/public")) {
+    return <>{children}</>;
+  }
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => setUser(data.user));

--- a/components/QRCode.tsx
+++ b/components/QRCode.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+interface QRCodeProps {
+  value: string;
+  size?: number;
+}
+
+export default function QRCode({ value, size = 200 }: QRCodeProps) {
+  const src = `https://api.qrserver.com/v1/create-qr-code/?size=${size}x${size}&data=${encodeURIComponent(
+    value
+  )}`;
+  return <img src={src} alt="QR code" width={size} height={size} />;
+}


### PR DESCRIPTION
## Summary
- add viewport meta to main layout
- skip login overlay for `/public` routes
- generate shareable public page for tournaments
- allow QR code sharing with a simple component

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687ce3950c4c83309ebc99e946053329