### PR TITLE
Add public tournament view

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,6 +26,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <LoginOverlay>
           <Header />

--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { supabase } from "../../../lib/supabaseBrowser";
 
 interface Match {
@@ -22,6 +22,7 @@ interface Team {
 export default function TournamentViewPage() {
   const params = useParams();
   const id = params?.id as string;
+  const router = useRouter();
 
   const [tournament, setTournament] = useState<any>(null);
   const [matches, setMatches] = useState<Match[]>([]);
@@ -75,6 +76,16 @@ export default function TournamentViewPage() {
         <h2 className="flex-1 text-xl font-bold">
           {tournament?.name || "Tournament"}
         </h2>
+        <button
+          onClick={() => {
+            setDebug((d) => [...d, `Share button clicked for ${id}`]);
+            console.debug('Share button clicked for', id);
+            router.push(`/tournaments/${id}/public`);
+          }}
+          className="px-3 py-1.5 text-sm rounded bg-blue-500 text-white hover:bg-blue-600"
+        >
+          Share
+        </button>
       </div>
       {debug.length > 0 && (
         <details className="text-sm border p-2 rounded">

--- a/app/tournaments/[id]/public/page.tsx
+++ b/app/tournaments/[id]/public/page.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { supabase } from '@/lib/supabaseBrowser';
+import QRCode from '@/components/QRCode';
+
+interface Team {
+  id: number;
+  name: string;
+}
+
+interface Match {
+  id: number;
+  team_a: number | null;
+  team_b: number | null;
+  result: string | null;
+  team1_name?: string;
+  team2_name?: string;
+}
+
+export default function PublicTournamentView() {
+  const { id } = useParams<{ id: string }>();
+  const [tournament, setTournament] = useState<any>(null);
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [matches, setMatches] = useState<Match[]>([]);
+  const [shareUrl, setShareUrl] = useState('');
+
+  useEffect(() => {
+    setShareUrl(window.location.href);
+  }, []);
+
+  useEffect(() => {
+    const loadData = async () => {
+      const { data: t } = await supabase
+        .from('tournaments')
+        .select('*')
+        .eq('id', id)
+        .single();
+      setTournament(t);
+
+      const { data: teamData } = await supabase
+        .from('tournament_teams')
+        .select('team_id, teams(id, name)')
+        .eq('tournament_id', id);
+      setTeams(
+        (teamData || []).map((tt: any) => ({
+          id: tt.team_id,
+          name: tt.teams?.name ?? ''
+        }))
+      );
+
+      const { data: matchData } = await supabase
+        .from('matches')
+        .select('*')
+        .eq('tournament_id', id)
+        .order('created_at', { ascending: true });
+      setMatches(matchData || []);
+    };
+
+    if (id) loadData();
+  }, [id]);
+
+  if (!tournament) return <div className="p-4">Loading...</div>;
+
+  const teamName = (tid: number | null) =>
+    tid === null ? 'BYE' : teams.find((t) => t.id === tid)?.name || 'Unknown';
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-2">{tournament.name}</h1>
+      <p className="mb-4 text-gray-600">Tournament in progress</p>
+
+      <h2 className="text-xl font-semibold mt-6">Teams</h2>
+      <ul className="list-disc list-inside">
+        {teams.map((team) => (
+          <li key={team.id}>{team.name}</li>
+        ))}
+      </ul>
+
+      <h2 className="text-xl font-semibold mt-6">Matches</h2>
+      <ul className="mt-2">
+        {matches.map((match, index) => (
+          <li key={match.id} className="border-b py-2">
+            Match {index + 1}: {teamName(match.team_a)} vs {teamName(match.team_b)} —{' '}
+            <strong>{match.result || 'TBD'}</strong>
+          </li>
+        ))}
+      </ul>
+
+      <button
+        onClick={() => {
+          console.debug('Public share invoked', shareUrl);
+          navigator.share?.({
+            title: tournament.name,
+            url: shareUrl,
+            text: 'Follow the tournament live!'
+          });
+        }}
+        className="mt-6 px-4 py-2 bg-blue-600 text-white rounded-lg"
+      >
+        Share with Participants
+      </button>
+
+      <div className="mt-6 flex justify-center">
+        <QRCode value={shareUrl} />
+      </div>
+    </div>
+  );
+}

--- a/app/tournaments/page.tsx
+++ b/app/tournaments/page.tsx
@@ -192,6 +192,7 @@ export default function TournamentsPage() {
       onSchedule={handleSchedule}
       onRun={(id) => router.push(`/run/${id}`)}
       onView={(id) => router.push(`/tournaments/${id}`)}
+      onShare={(id) => router.push(`/tournaments/${id}/public`)}
       onDelete={deleteTournament}
       loading={loading}
     />

--- a/components/LoginOverlay.tsx
+++ b/components/LoginOverlay.tsx
@@ -1,8 +1,11 @@
 "use client";
 import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 import { supabase } from "../lib/supabaseBrowser";
 
 export default function LoginOverlay({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isPublic = pathname.includes("/public");
   const [user, setUser] = useState<any>(undefined);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -14,6 +17,7 @@ export default function LoginOverlay({ children }: { children: React.ReactNode }
   const [message, setMessage] = useState("");
 
   useEffect(() => {
+    if (isPublic) return;
     supabase.auth.getUser().then(({ data }) => setUser(data.user));
     const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
       if (event === "PASSWORD_RECOVERY") {
@@ -24,7 +28,7 @@ export default function LoginOverlay({ children }: { children: React.ReactNode }
       }
     });
     return () => sub.subscription.unsubscribe();
-  }, []);
+  }, [isPublic]);
 
   const loginUser = async () => {
     const { error } = await supabase.auth.signInWithPassword({
@@ -91,7 +95,7 @@ export default function LoginOverlay({ children }: { children: React.ReactNode }
     setPassword("");
   }, [phase]);
 
-  if (!user) {
+  if (!user && !isPublic) {
     return (
       <div className="fixed inset-0 flex items-center justify-center bg-white z-50">
         <div className="space-y-4 max-w-sm p-4 border bg-white">

--- a/components/QRCode.tsx
+++ b/components/QRCode.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+interface QRCodeProps {
+  value: string;
+  size?: number;
+}
+
+export default function QRCode({ value, size = 200 }: QRCodeProps) {
+  const src = `https://api.qrserver.com/v1/create-qr-code/?size=${size}x${size}&data=${encodeURIComponent(
+    value
+  )}`;
+  return <img src={src} alt="QR code" width={size} height={size} />;
+}

--- a/components/TournamentsView.tsx
+++ b/components/TournamentsView.tsx
@@ -20,6 +20,7 @@ interface Props {
   onSchedule: (name: string, teamIds: string[]) => void | Promise<void>;
   onRun: (id: string) => void;
   onView: (id: string) => void;
+  onShare: (id: string) => void;
   onDelete: (id: string) => void;
   loading?: boolean;
 }
@@ -30,6 +31,7 @@ export default function TournamentsView({
   onSchedule,
   onRun,
   onView,
+  onShare,
   onDelete,
   loading,
 }: Props) {
@@ -104,6 +106,15 @@ export default function TournamentsView({
               </Button>
               <Button className="bg-emerald-600 hover:bg-emerald-700" onClick={() => onView(tournament.id)}>
                 View
+              </Button>
+              <Button
+                className="bg-blue-500 hover:bg-blue-600"
+                onClick={() => {
+                  console.debug('Share button clicked for', tournament.id);
+                  onShare(tournament.id);
+                }}
+              >
+                Share
               </Button>
               <Button variant="destructive" onClick={() => onDelete(tournament.id)}>
                 Delete


### PR DESCRIPTION
## Summary
- add viewport meta to main layout
- skip login overlay for `/public` routes
- generate shareable public page for tournaments
- allow QR code sharing with a simple component
- add share buttons for tournaments
- add debug logs for Share buttons
- fix hooks order in LoginOverlay

## Testing
- `npm run lint` *(fails: `next: not found`)*


------
https://chatgpt.com/codex/tasks/task_e_687ce3950c4c83309ebc99e946053329