### PR TITLE
Fix runtime error when sharing

### DIFF
--- a/components/LoginOverlay.tsx
+++ b/components/LoginOverlay.tsx
@@ -16,10 +16,6 @@ export default function LoginOverlay({ children }: { children: React.ReactNode }
     );
   const [message, setMessage] = useState("");
 
-  if (pathname.includes("/public")) {
-    return <>{children}</>;
-  }
-
   useEffect(() => {
     if (isPublic) return;
     supabase.auth.getUser().then(({ data }) => setUser(data.user));
@@ -98,6 +94,10 @@ export default function LoginOverlay({ children }: { children: React.ReactNode }
     setCode("");
     setPassword("");
   }, [phase]);
+
+  if (isPublic) {
+    return <>{children}</>;
+  }
 
   if (!user && !isPublic) {
     return (


### PR DESCRIPTION
## Summary
- maintain consistent hook order in `LoginOverlay`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cf09b49408330ad1b60629949e6a7