### PR TITLE
Fix share page QR code URL

### DIFF
--- a/app/tournaments/[id]/public/page.tsx
+++ b/app/tournaments/[id]/public/page.tsx
@@ -27,8 +27,10 @@ export default function PublicTournamentView() {
   const [shareUrl, setShareUrl] = useState('');
 
   useEffect(() => {
-    setShareUrl(window.location.href);
-  }, []);
+    // Always share the canonical public URL for the tournament
+    const url = `${window.location.origin}/tournaments/${id}/public`;
+    setShareUrl(url);
+  }, [id]);
 
   useEffect(() => {
     const loadData = async () => {


### PR DESCRIPTION
## Summary
- share the canonical public tournament URL instead of the current page

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687cf3bc937083309f355855b35c4a7b