### PR TITLE
Add Supabase tournament create & demo pages

### DIFF
--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -1,30 +1,45 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+
 export default function DemoPage() {
+  const [tournament, setTournament] = useState(null);
+  const [teams, setTeams] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: t } = await supabase
+        .from('tournaments')
+        .select('*')
+        .eq('id', 'a073d974-4da1-4fd1-a026-3db7a9bebca0')
+        .single();
+      setTournament(t);
+
+      const { data: teamData } = await supabase
+        .from('teams')
+        .select('*')
+        .eq('tournament_id', t?.id);
+      setTeams(teamData || []);
+    };
+    load();
+  }, []);
+
+  if (!tournament) return <p className="p-6 text-center text-gray-500">Loading demo...</p>;
+
   return (
-    <main className="max-w-5xl mx-auto p-6">
+    <main className="max-w-4xl mx-auto p-6">
       <h1 className="text-3xl font-bold text-indigo-700 mb-4 text-center">
-        Try the Tournament Demo
+        Demo: {tournament.name}
       </h1>
-      <p className="text-lg text-center text-gray-600 mb-8">
-        See how easy it is to manage a tournament. This is a fully interactive preview – no login required.
-      </p>
+      <p className="text-center text-gray-600 mb-6">Sport: {tournament.sport}</p>
 
-      {/* Example bracket or mock match UI */}
-      <div className="bg-white shadow rounded-lg p-6 mb-6">
-        <h2 className="text-xl font-semibold mb-4">Tournament Preview</h2>
-        <ul className="space-y-3">
-          <li>🏓 Round 1: Team A vs Team B – 3:2</li>
-          <li>🏓 Round 1: Team C vs Team D – 1:3</li>
-          <li>🏆 Semifinal: Team B vs Team D – Pending</li>
-        </ul>
-      </div>
-
-      {/* CTA */}
-      <div className="text-center">
-        <p className="text-gray-600 mb-4">Ready to make your own?</p>
-        <a href="/create" className="bg-indigo-600 text-white px-6 py-3 rounded-lg hover:bg-indigo-700">
-          Create Your Tournament
-        </a>
-      </div>
+      <ul className="bg-white shadow rounded-lg p-6 space-y-2">
+        {teams.map(team => (
+          <li key={team.id} className="text-lg text-gray-700">
+            ⚽ {team.name}
+          </li>
+        ))}
+      </ul>
     </main>
   );
 }

--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "next": "15.3.5",
-    "@supabase/supabase-js": "^2.39.8"
+    "@supabase/supabase-js": "^2.39.8",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- connect to Supabase with new `lib/supabaseClient.js`
- implement create-tournament page using Supabase to store tournaments and teams
- load demo tournament from Supabase
- add `uuid` dependency

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687df745735c83308629a2df63d39acb