### PR TITLE
Fix tournament redirect path

### DIFF
--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -41,7 +41,7 @@ export default function CreatePage() {
     }
 
     setLoading(false);
-    window.location.href = `/tournament/${tournamentId}`;
+    window.location.href = `/tournaments/${tournamentId}`;
   };
 
   return (


### PR DESCRIPTION
## Summary
- navigate to the correct route after creating a tournament

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e13c6a06083308a5fc85bb1d6df39