### PR TITLE
Add database cleanup button

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -84,6 +84,37 @@ export default function SettingsPage() {
     alert("All data deleted.");
   };
 
+  const cleanupDatabase = async () => {
+    if (
+      !confirm(
+        "Remove all records without a user? This cannot be undone."
+      )
+    )
+      return;
+
+    const tables = [
+      "matches",
+      "tournament_teams",
+      "team_players",
+      "teams",
+      "tournaments",
+      "players",
+    ];
+
+    for (const table of tables) {
+      const { error } = await supabase
+        .from(table)
+        .delete()
+        .is("user_id", null);
+      if (error) {
+        alert(`Failed cleaning ${table}: ${error.message}`);
+        return;
+      }
+    }
+
+    alert("Database cleanup complete.");
+  };
+
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">
       <h2 className="text-2xl font-semibold">Settings</h2>
@@ -133,9 +164,14 @@ export default function SettingsPage() {
         <p className="text-sm text-red-700">
           This will permanently remove all your players, teams and tournaments.
         </p>
-        <Button variant="destructive" onClick={deleteAllData}>
-          Delete My Data
-        </Button>
+        <div className="flex space-x-2">
+          <Button variant="destructive" onClick={deleteAllData}>
+            Delete My Data
+          </Button>
+          <Button variant="destructive" onClick={cleanupDatabase}>
+            Database cleanup
+          </Button>
+        </div>
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow removing stray entries with no user via Settings page
- spacing between danger zone buttons
- fix database cleanup query

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*
- `npm run cleanup` *(fails: `Cannot find package '@supabase/supabase-js'`)*

------
https://chatgpt.com/codex/tasks/task_e_687e32a7b1448330b5855318534cc128