### PR TITLE
Fix database cleanup button

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -84,6 +84,36 @@ export default function SettingsPage() {
     alert("All data deleted.");
   };
 
+  const cleanupDatabase = async () => {
+    if (
+      !confirm(
+        "Remove all records without a user? This cannot be undone."
+      )
+    )
+      return;
+
+    const tables = [
+      "matches",
+      "team_players",
+      "teams",
+      "tournaments",
+      "players",
+    ];
+
+    for (const table of tables) {
+      const { error } = await supabase
+        .from(table)
+        .delete()
+        .is("user_id", null);
+      if (error) {
+        alert(`Failed cleaning ${table}: ${error.message}`);
+        return;
+      }
+    }
+
+    alert("Database cleanup complete.");
+  };
+
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">
       <h2 className="text-2xl font-semibold">Settings</h2>
@@ -133,9 +163,14 @@ export default function SettingsPage() {
         <p className="text-sm text-red-700">
           This will permanently remove all your players, teams and tournaments.
         </p>
-        <Button variant="destructive" onClick={deleteAllData}>
-          Delete My Data
-        </Button>
+        <div className="flex space-x-2">
+          <Button variant="destructive" onClick={deleteAllData}>
+            Delete My Data
+          </Button>
+          <Button variant="destructive" onClick={cleanupDatabase}>
+            Database cleanup
+          </Button>
+        </div>
       </section>
     </div>
   );

--- a/scripts/cleanup.js
+++ b/scripts/cleanup.js
@@ -13,7 +13,6 @@ const supabase = createClient(url, key);
 async function cleanup() {
   const tables = [
     'matches',
-    'tournament_teams',
     'team_players',
     'teams',
     'tournaments',
@@ -24,7 +23,7 @@ async function cleanup() {
     const { error } = await supabase
       .from(table)
       .delete()
-      .or('user_id.is.null,user_id.eq.""');
+      .is('user_id', null);
     if (error) {
       console.error(`Failed cleaning ${table}:`, error.message);
     }


### PR DESCRIPTION
## Summary
- update cleanup routine to skip tables without a user_id column
- remove empty-string check and just delete null user_id rows
- space out danger zone buttons

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*
- `npm run cleanup` *(fails: `Cannot find package '@supabase/supabase-js'`)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687e32a7b1448330b5855318534cc128