### PR TITLE
Add delete all tournaments button

### DIFF
--- a/app/tournaments/page.tsx
+++ b/app/tournaments/page.tsx
@@ -106,6 +106,33 @@ export default function TournamentsPage() {
     setTournaments((prev) => prev.filter((t) => t.id !== id));
   };
 
+  const deleteAllTournaments = async () => {
+    if (!user) return;
+    if (tournaments.length === 0) return;
+    if (!confirm("Delete ALL tournaments?")) return;
+    setLoading(true);
+    try {
+      const ids = tournaments.map((t) => t.id);
+      await supabase
+        .from("matches")
+        .delete()
+        .in("tournament_id", ids)
+        .eq("user_id", user.id);
+      await supabase
+        .from("tournament_teams")
+        .delete()
+        .in("tournament_id", ids);
+      await supabase
+        .from("tournaments")
+        .delete()
+        .in("id", ids)
+        .eq("user_id", user.id);
+      setTournaments([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   async function generateSchedule(id: string) {
     const { data: userData } = await supabase.auth.getUser();
     const currentUser = userData.user;
@@ -194,6 +221,7 @@ export default function TournamentsPage() {
       onView={(id) => router.push(`/tournaments/${id}`)}
       onShare={(id) => router.push(`/tournaments/${id}/public`)}
       onDelete={deleteTournament}
+      onDeleteAll={deleteAllTournaments}
       loading={loading}
     />
   );

--- a/components/TournamentsView.tsx
+++ b/components/TournamentsView.tsx
@@ -22,6 +22,7 @@ interface Props {
   onView: (id: string) => void;
   onShare: (id: string) => void;
   onDelete: (id: string) => void;
+  onDeleteAll: () => void;
   loading?: boolean;
 }
 
@@ -33,6 +34,7 @@ export default function TournamentsView({
   onView,
   onShare,
   onDelete,
+  onDeleteAll,
   loading,
 }: Props) {
   const [selectedTeams, setSelectedTeams] = useState<string[]>([]);
@@ -88,7 +90,12 @@ export default function TournamentsView({
 
       {/* Tournaments List */}
       <section className="space-y-4">
-        <h2 className="text-xl font-semibold">Tournaments</h2>
+        <div className="flex justify-between items-center">
+          <h2 className="text-xl font-semibold">Tournaments</h2>
+          <Button variant="destructive" onClick={onDeleteAll}>
+            Delete all
+          </Button>
+        </div>
 
         {tournaments.map((tournament) => (
           <div


### PR DESCRIPTION
## Summary
- add `onDeleteAll` prop to `TournamentsView`
- implement delete-all button in UI
- support deleting all tournaments on the page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f24299b508330a975500da069ee34