### PR TITLE
Add Delete All button for teams

### DIFF
--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -184,6 +184,49 @@ export default function TeamsPage() {
     setTeams((prev) => prev.filter((t) => t.id !== id));
   };
 
+  const deleteAllTeams = async () => {
+    if (!user) return;
+    if (teams.length === 0) return;
+    if (!confirm("Delete ALL teams?")) return;
+    setLoading(true);
+    try {
+      const ids = teams.map((t) => t.id);
+      await supabase
+        .from("team_players")
+        .delete()
+        .in("team_id", ids)
+        .eq("user_id", user.id);
+
+      await supabase
+        .from("matches")
+        .update({ team_a: null })
+        .in("team_a", ids)
+        .eq("user_id", user.id);
+
+      await supabase
+        .from("matches")
+        .update({ team_b: null })
+        .in("team_b", ids)
+        .eq("user_id", user.id);
+
+      await supabase
+        .from("matches")
+        .update({ winner: null })
+        .in("winner", ids)
+        .eq("user_id", user.id);
+
+      await supabase
+        .from("teams")
+        .delete()
+        .in("id", ids)
+        .eq("user_id", user.id);
+
+      setTeams([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const generateBalancedTeams = async () => {
     if (!user) return;
     setLoading(true);
@@ -240,6 +283,7 @@ export default function TeamsPage() {
       onAdd={addTeam}
       onEdit={editTeam}
       onDelete={deleteTeam}
+      onDeleteAll={deleteAllTeams}
       onGenerateBalanced={generateBalancedTeams}
       loading={loading}
     />

--- a/components/TeamsView.tsx
+++ b/components/TeamsView.tsx
@@ -23,6 +23,7 @@ interface Props {
   onEdit: (team: Team) => void;
   onDelete: (id: number) => void;
   onGenerateBalanced: () => void;
+  onDeleteAll: () => void;
   loading?: boolean;
 }
 
@@ -43,6 +44,7 @@ export default function TeamsView({
   onEdit,
   onDelete,
   onGenerateBalanced,
+  onDeleteAll,
   loading,
 }: Props) {
   const [selectedPlayers, setSelectedPlayers] = useState<number[]>([]);
@@ -74,9 +76,14 @@ export default function TeamsView({
       {/* Header */}
       <div className="flex justify-between items-center">
         <h2 className="text-2xl font-semibold">Teams</h2>
-        <Button variant="outline" onClick={onGenerateBalanced}>
-          AI balanced teams
-        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={onGenerateBalanced}>
+            AI balanced teams
+          </Button>
+          <Button variant="destructive" onClick={onDeleteAll}>
+            Delete all
+          </Button>
+        </div>
       </div>
 
       {/* Add New Team */}


### PR DESCRIPTION
## Summary
- add `onDeleteAll` prop to `TeamsView`
- add Delete all button to the Teams header
- implement `deleteAllTeams` in the Teams page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f27222aac8330933b7ea92bb83953