### PR TITLE
Improve player and team views

### DIFF
--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -142,19 +142,25 @@ export default function TeamsPage() {
   const editTeam = async (team: TeamRow) => {
     if (!userId) return;
     const name = window.prompt("Team name", team.name) ?? team.name;
-    const idsStr = window.prompt(
-      `Player IDs (comma separated, choose ${teamSize} from ${players
-        .map((p) => p.id)
+    const currentNames = team.playerIds
+      .map((id) => players.find((p) => p.id === id)?.name || "")
+      .join(",");
+    const namesStr = window.prompt(
+      `Player names (comma separated, choose ${teamSize} from ${players
+        .map((p) => p.name)
         .join(", ")})`,
-      team.playerIds.join(",")
+      currentNames
     );
-    const ids = idsStr
-      ? idsStr
+    const names = namesStr
+      ? namesStr
           .split(",")
           .map((s) => s.trim())
           .filter(Boolean)
           .slice(0, teamSize)
-      : team.playerIds;
+      : currentNames.split(",").map((s) => s.trim()).filter(Boolean);
+    const ids = names
+      .map((n) => players.find((p) => p.name === n)?.id)
+      .filter((id): id is string => Boolean(id));
     if (!name || ids.length !== teamSize) return;
 
     await supabase

--- a/components/PlayersView.tsx
+++ b/components/PlayersView.tsx
@@ -6,6 +6,7 @@ import { Button } from "./ui/button";
 export default function PlayersView() {
   const [userId, setUserId] = useState<string | null>(null);
   const [sportId, setSportId] = useState<string | null>(null);
+  const [sportName, setSportName] = useState<string>("");
   const [skillsList, setSkillsList] = useState<string[]>([]);
   const [players, setPlayers] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
@@ -42,20 +43,21 @@ export default function PlayersView() {
     getSport();
   }, [userId]);
 
-  // 3. Load sport skill list
+  // 3. Load sport info (skills and name)
   useEffect(() => {
     if (!sportId) return;
 
-    const getSkills = async () => {
+    const getSportInfo = async () => {
       const { data } = await supabase
         .from("sports")
-        .select("skills")
+        .select("skills, display_name")
         .eq("id", sportId)
         .single();
       if (data?.skills) setSkillsList(data.skills as string[]);
+      if (data?.display_name) setSportName(data.display_name as string);
     };
 
-    getSkills();
+    getSportInfo();
   }, [sportId]);
 
   // 4. Load all players and their profile for current sport
@@ -187,7 +189,14 @@ export default function PlayersView() {
 
   return (
     <div className="max-w-2xl mx-auto p-6">
-      <h1 className="text-xl font-bold mb-4">Players</h1>
+      <h1 className="text-xl font-bold mb-4 flex items-baseline gap-2">
+        Players
+        {sportName && (
+          <span className="text-sm text-gray-500 font-normal">
+            {sportName} ({players.length})
+          </span>
+        )}
+      </h1>
 
       <div className="mb-6 flex gap-2">
         <input


### PR DESCRIPTION
## Summary
- show sport name and player count in `PlayersView` header
- edit teams using player names instead of IDs

## Testing
- `npm run lint` *(fails: `next` not found because dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_68872db208108330b0b3b6f4fb0961e6