### PR TITLE
Add format options and match scheduling utilities

### DIFF
--- a/components/TournamentsView.tsx
+++ b/components/TournamentsView.tsx
@@ -17,7 +17,11 @@ interface Tournament {
 interface Props {
   tournaments: Tournament[];
   teams: Team[];
-  onSchedule: (name: string, teamIds: string[]) => void | Promise<void>;
+  onSchedule: (
+    name: string,
+    teamIds: string[],
+    format: 'round_robin' | 'knockout'
+  ) => void | Promise<void>;
   onRun: (id: string) => void;
   onView: (id: string) => void;
   onShare: (id: string) => void;
@@ -38,6 +42,7 @@ export default function TournamentsView({
   loading,
 }: Props) {
   const [selectedTeams, setSelectedTeams] = useState<string[]>([]);
+  const [format, setFormat] = useState<'round_robin' | 'knockout'>('round_robin');
 
   const toggleTeam = (id: string) => {
     setSelectedTeams((prev) =>
@@ -49,7 +54,7 @@ export default function TournamentsView({
     e.preventDefault();
     const form = e.currentTarget;
     const name = (form.elements.namedItem("tournamentName") as HTMLInputElement).value;
-    onSchedule(name, selectedTeams);
+    onSchedule(name, selectedTeams, format);
     setSelectedTeams([]);
     form.reset();
   };
@@ -81,6 +86,18 @@ export default function TournamentsView({
             getLabel={(t) => t.name}
             maxHeight="max-h-32"
           />
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Tournament Format</label>
+            <select
+              value={format}
+              onChange={(e) => setFormat(e.target.value as 'round_robin' | 'knockout')}
+              className="border rounded px-2 py-1"
+            >
+              <option value="round_robin">Round Robin</option>
+              <option value="knockout">Knockout</option>
+            </select>
+          </div>
 
           <Button type="submit" className="mt-2 bg-emerald-600 hover:bg-emerald-700">
             AI Schedule

--- a/utils/scheduleMatches.ts
+++ b/utils/scheduleMatches.ts
@@ -1,0 +1,30 @@
+export function generateRoundRobinMatches(teamIds: string[]): { team_a: string, team_b: string, phase: string }[] {
+  const matches = [] as { team_a: string; team_b: string; phase: string }[];
+  for (let i = 0; i < teamIds.length; i++) {
+    for (let j = i + 1; j < teamIds.length; j++) {
+      matches.push({
+        team_a: teamIds[i],
+        team_b: teamIds[j],
+        phase: `Matchday ${matches.length + 1}`,
+      });
+    }
+  }
+  return matches;
+}
+
+export function generateKnockoutMatches(teamIds: string[]): { team_a: string, team_b: string, phase: string }[] {
+  const matches = [] as { team_a: string; team_b: string; phase: string }[];
+  const shuffled = [...teamIds].sort(() => Math.random() - 0.5);
+
+  while (shuffled.length > 1) {
+    const team_a = shuffled.shift()!;
+    const team_b = shuffled.shift()!;
+    matches.push({ team_a, team_b, phase: 'Round 1' });
+  }
+
+  if (shuffled.length === 1) {
+    matches.push({ team_a: shuffled[0], team_b: '', phase: 'BYE' });
+  }
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- allow choosing tournament format in setup
- persist format when creating tournaments
- provide helpers for round robin and knockout schedules
- display format on tournament detail page and group matches by phase
- enable on-demand schedule generation when no matches exist

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688783aab690833093c60b3d092f323c