### PR TITLE
Fix skills display after CSV import

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -112,6 +112,16 @@ export default function SettingsPage() {
         return;
       }
 
+      // If the CSV header defines the skills, update the sport info so
+      // the Players view knows about them
+      if (header.length) {
+        await supabase
+          .from("sports")
+          .update({ skills })
+          .eq("id", selectedSportId);
+        setSportSkills(skills);
+      }
+
       const players: { name: string; user_id: string }[] = [];
       const profiles: Record<string, number>[] = [];
 


### PR DESCRIPTION
## Summary
- ensure new skill headers from CSV are stored in the sport

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68878d1cf6b8833093e599065b660b26