### PR TITLE
Fix null player runtime error

### DIFF
--- a/components/PlayersView.tsx
+++ b/components/PlayersView.tsx
@@ -72,12 +72,14 @@ export default function PlayersView() {
         .eq("players.user_id", userId)
         .order("name", { foreignTable: "players" });
 
-      const playersWithProfiles = (data || []).map((row: any) => ({
-        id: row.players.id,
-        name: row.players.name,
-        profile_id: row.id,
-        skills: row.skills || {},
-      }));
+      const playersWithProfiles = (data || [])
+        .filter((row: any) => row.players)
+        .map((row: any) => ({
+          id: row.players.id,
+          name: row.players.name,
+          profile_id: row.id,
+          skills: row.skills || {},
+        }));
 
       setPlayers(sortPlayers(playersWithProfiles));
       setLoading(false);


### PR DESCRIPTION
## Summary
- fix runtime error when players list includes null entries by filtering them out

## Testing
- `npm test` *(fails: `/usr/bin/npm: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6887995997a88330bc416540cd6dc668