### PR TITLE
Filter blank/duplicate skills

### DIFF
--- a/components/PlayersView.tsx
+++ b/components/PlayersView.tsx
@@ -53,7 +53,12 @@ export default function PlayersView() {
         .select("skills, display_name")
         .eq("id", sportId)
         .single();
-      if (data?.skills) setSkillsList(data.skills as string[]);
+      if (data?.skills) {
+        const uniqueSkills = Array.from(
+          new Set((data.skills as string[]).filter(Boolean))
+        );
+        setSkillsList(uniqueSkills);
+      }
       if (data?.display_name) setSportName(data.display_name as string);
     };
 


### PR DESCRIPTION
## Summary
- sanitize sport skills when loading PlayersView to remove blank or duplicate skill names

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68879bc33d58833082235a3b0d0e79c6