### PR TITLE
Fix teams page player duplication and correct team score

### DIFF
--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -60,18 +60,20 @@ export default function TeamsPage() {
   useEffect(() => {
     if (!sportId || !userId) return;
     const load = async () => {
-      const { data: playerRows } = await supabase
-        .from("players")
-        .select("id, name, player_profiles(id, skills)")
-        .eq("user_id", userId)
-        .eq("player_profiles.sport_id", sportId)
-        .order("name");
+      const { data: rows } = await supabase
+        .from("player_profiles")
+        .select("skills, players(id, name)")
+        .eq("sport_id", sportId)
+        .eq("players.user_id", userId)
+        .order("players.name");
 
-      const playersWithSkills = (playerRows || []).map((p: any) => ({
-        id: p.id,
-        name: p.name,
-        skills: p.player_profiles?.skills || {},
-      })) as Player[];
+      const playersWithSkills = (rows || [])
+        .filter((r: any) => r.players)
+        .map((r: any) => ({
+          id: r.players.id,
+          name: r.players.name,
+          skills: r.skills || {},
+        })) as Player[];
 
       setPlayers(playersWithSkills);
 

--- a/components/TeamsView.tsx
+++ b/components/TeamsView.tsx
@@ -33,8 +33,11 @@ function averageSkill(player: Player): number {
 }
 
 function teamScore(ids: string[], players: Player[]): number {
-  const values = ids.map((id) => averageSkill(players.find((p) => p.id === id)!));
-  return Math.round(values.reduce((a, b) => a + b, 0));
+  const values = ids
+    .map((id) => averageSkill(players.find((p) => p.id === id)!))
+    .filter((v) => !isNaN(v));
+  if (!values.length) return 0;
+  return Math.round(values.reduce((a, b) => a + b, 0) / values.length);
 }
 
 export default function TeamsView({


### PR DESCRIPTION
## Summary
- deduplicate player query on teams page
- compute average team score instead of total

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887b066010c83308c81e385327a8680