### PR TITLE
Fix player order query in Teams page

### DIFF
--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -65,7 +65,7 @@ export default function TeamsPage() {
         .select("skills, players(id, name)")
         .eq("sport_id", sportId)
         .eq("players.user_id", userId)
-        .order("players.name");
+        .order("name", { foreignTable: "players" });
 
       const playersWithSkills = (rows || [])
         .filter((r: any) => r.players)


### PR DESCRIPTION
## Summary
- fix player ordering query for Teams page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6887b3860c0c83308636d92cabda1f7d