### PR TITLE
Add knockout phase after round robin

### DIFF
--- a/app/run/[id]/page.tsx
+++ b/app/run/[id]/page.tsx
@@ -294,6 +294,66 @@ export default function TournamentRunPage() {
     }
   }, [matches, celebrated]);
 
+  useEffect(() => {
+    const maybeGenerateKnockout = async () => {
+      if (!tournament || tournament.format !== 'round_robin') return;
+      if (matches.length === 0) return;
+      const rrMatches = matches.filter((m) => !m.phase.startsWith('round'));
+      const knockoutExists = matches.some((m) => m.phase.startsWith('round'));
+      if (knockoutExists) return;
+      if (rrMatches.length === 0) return;
+      const allDone = rrMatches.every((m) => m.winner);
+      if (!allDone) return;
+
+      const stats: Record<string, { wins: number; diff: number }> = {};
+      teams.forEach((t) => {
+        stats[String(t.id)] = { wins: 0, diff: 0 };
+      });
+      rrMatches.forEach((m) => {
+        if (m.winner !== null) {
+          stats[String(m.winner)].wins += 1;
+        }
+        if (m.score_a !== null && m.score_b !== null) {
+          stats[String(m.team_a)].diff += m.score_a - m.score_b;
+          stats[String(m.team_b)].diff += m.score_b - m.score_a;
+        }
+      });
+      const ranked = Object.entries(stats)
+        .sort((a, b) => {
+          if (b[1].wins !== a[1].wins) return b[1].wins - a[1].wins;
+          return b[1].diff - a[1].diff;
+        })
+        .map(([id]) => Number(id));
+      const count = ranked.length >= 4 ? 4 : 2;
+      const top = ranked.slice(0, count);
+      const pairings: { team_a: number; team_b: number }[] = [];
+      if (top.length === 4) {
+        pairings.push({ team_a: top[0], team_b: top[3] });
+        pairings.push({ team_a: top[1], team_b: top[2] });
+      } else if (top.length === 2) {
+        pairings.push({ team_a: top[0], team_b: top[1] });
+      } else {
+        return;
+      }
+      await supabase.from('matches').insert(
+        pairings.map((p) => ({
+          team_a: p.team_a,
+          team_b: p.team_b,
+          phase: 'round1',
+          scheduled_at: null,
+          tournament_id: id,
+          user_id: user?.id ?? null,
+        }))
+      );
+      const { data: newMatches } = await supabase
+        .from('matches')
+        .select('*')
+        .eq('tournament_id', id);
+      setMatches(newMatches || []);
+    };
+    maybeGenerateKnockout();
+  }, [matches, tournament, teams, id, user]);
+
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-bold">{tournament?.name || "Tournament"} Run</h2>


### PR DESCRIPTION
## Summary
- when a round-robin tournament finishes all matches, rank by wins/score
- create knockout pairings for top teams automatically

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887c0e32ffc8330a22481a89cdb9696