### PR TITLE
Fix knockout seeding after round robin

### DIFF
--- a/app/run/[id]/page.tsx
+++ b/app/run/[id]/page.tsx
@@ -243,7 +243,7 @@ export default function TournamentRunPage() {
   const generateKnockout = async () => {
     const knockoutCount = (total: number) => {
       let count = 2;
-      while (total > count * 2 + 1) {
+      while (count * 2 <= total && count < 8) {
         count *= 2;
       }
       return count;


### PR DESCRIPTION
## Summary
- ensure at least top 2/4/8 teams advance to knockout phase

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68887c61bd9c8330a4e92e2241a865d0