### PR TITLE
Fix knockout pairings when team IDs use UUIDs

### DIFF
--- a/app/run/[id]/page.tsx
+++ b/app/run/[id]/page.tsx
@@ -228,8 +228,8 @@ export default function TournamentRunPage() {
     };
 
     const count = Math.min(knockoutCount(teams.length), rankings.length);
-    const topIds = rankings.slice(0, count).map((r) => Number(r.id));
-    const pairings: { team_a: number; team_b: number }[] = [];
+    const topIds = rankings.slice(0, count).map((r) => r.id);
+    const pairings: { team_a: string | number; team_b: string | number }[] = [];
     for (let i = 0; i < topIds.length / 2; i++) {
       pairings.push({
         team_a: topIds[i],


### PR DESCRIPTION
## Summary
- keep IDs as strings when generating knockout pairings

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888ce337610833083a0afd3c4767d22