### PR TITLE
Add donation prompt modal

### DIFF
--- a/components/DonationModal.tsx
+++ b/components/DonationModal.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+
+export default function DonationModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogTitle>Support the Developer</DialogTitle>
+        <DialogDescription>
+          You’ve created over 50 players — amazing! If you like the app, consider donating to support its development.
+        </DialogDescription>
+        <div className="mt-4 flex justify-end">
+          <a
+            href="https://buy.stripe.com/3cIfZie5z8KwcAq9xDak000"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bg-yellow-500 text-white px-4 py-2 rounded hover:bg-yellow-600"
+          >
+            Donate
+          </a>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/PlayersView.tsx
+++ b/components/PlayersView.tsx
@@ -2,6 +2,8 @@
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabaseBrowser";
 import { Button } from "./ui/button";
+import { useDonationPrompt } from "@/hooks/useDonationPrompt";
+import DonationModal from "./DonationModal";
 
 export default function PlayersView() {
   const [userId, setUserId] = useState<string | null>(null);
@@ -12,6 +14,8 @@ export default function PlayersView() {
   const [loading, setLoading] = useState(true);
   const [newPlayerName, setNewPlayerName] = useState<string>("");
   const [filter, setFilter] = useState<string>("");
+
+  const shouldPrompt = useDonationPrompt(players.length);
 
   const sortPlayers = (list: any[]) =>
     list.slice().sort((a, b) => a.name.localeCompare(b.name));
@@ -186,7 +190,9 @@ export default function PlayersView() {
   if (loading) return <p className="p-4">Loading players...</p>;
 
   return (
-    <div className="max-w-2xl mx-auto p-6">
+    <>
+      {shouldPrompt && <DonationModal open={true} onClose={() => {}} />}
+      <div className="max-w-2xl mx-auto p-6">
       <h1 className="text-xl font-bold mb-4 flex items-baseline gap-2">
         Players
         {sportName && (
@@ -262,6 +268,7 @@ export default function PlayersView() {
             ))}
           </div>
         ))}
-    </div>
+      </div>
+    </>
   );
 }

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from "react";
+
+interface DialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+}
+
+export function Dialog({ open, onOpenChange, children }: DialogProps) {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      onClick={() => onOpenChange(false)}
+    >
+      <div className="absolute inset-0 bg-black opacity-50" />
+      <div className="relative z-10" onClick={(e) => e.stopPropagation()}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function DialogContent({ children }: { children: ReactNode }) {
+  return (
+    <div className="bg-white p-6 rounded shadow-lg max-w-sm w-full">
+      {children}
+    </div>
+  );
+}
+
+export function DialogTitle({ children }: { children: ReactNode }) {
+  return <h2 className="text-lg font-bold">{children}</h2>;
+}
+
+export function DialogDescription({ children }: { children: ReactNode }) {
+  return <p className="mt-2 text-sm text-gray-600">{children}</p>;
+}

--- a/hooks/useDonationPrompt.ts
+++ b/hooks/useDonationPrompt.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+const donationThreshold = 50; // Customize this
+
+export function useDonationPrompt(playersCount: number) {
+  const [shouldShowPrompt, setShouldShowPrompt] = useState(false);
+
+  useEffect(() => {
+    const alreadyPrompted = localStorage.getItem("donationPrompted");
+    if (!alreadyPrompted && playersCount >= donationThreshold) {
+      setShouldShowPrompt(true);
+      localStorage.setItem("donationPrompted", "true");
+    }
+  }, [playersCount]);
+
+  return shouldShowPrompt;
+}


### PR DESCRIPTION
## Summary
- add a `useDonationPrompt` hook for tracking player count
- implement modal components for donation prompt
- show donation modal in `PlayersView`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888eb3495908330b8bba12c1ab56da5