### PR TITLE
Add donation overlay hook and modal

### DIFF
--- a/components/DonationModal.tsx
+++ b/components/DonationModal.tsx
@@ -1,20 +1,47 @@
 "use client";
-import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 
-export default function DonationModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+
+export default function DonationModal({
+  onClose,
+  stripeLink,
+}: {
+  onClose: () => void;
+  stripeLink: string;
+}) {
   return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent>
-        <DialogTitle>Support the Developer</DialogTitle>
-        <DialogDescription>
-          You’ve created over 50 players — amazing! If you like the app, consider donating to support its development.
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-md">
+        <DialogTitle className="text-xl font-semibold">
+          You're clearly enjoying the app 🎉
+        </DialogTitle>
+        <DialogDescription className="mt-2 space-y-3 text-sm text-muted-foreground">
+          <p>You've added over 50 players — that’s amazing!</p>
+          <p>
+            This app is crafted with ❤️ by an indie developer and is completely free to use.
+          </p>
+          <p>
+            If it’s helping you run great tournaments, would you consider a small donation to support
+            future improvements?
+          </p>
         </DialogDescription>
-        <div className="mt-4 flex justify-end">
+        <div className="mt-4 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="rounded px-4 py-2 border border-gray-300 hover:bg-gray-100 text-sm"
+          >
+            Later
+          </button>
           <a
-            href="https://buy.stripe.com/3cIfZie5z8KwcAq9xDak000"
+            href={stripeLink}
             target="_blank"
             rel="noopener noreferrer"
-            className="bg-yellow-500 text-white px-4 py-2 rounded hover:bg-yellow-600"
+            className="bg-yellow-500 text-white text-sm px-4 py-2 rounded hover:bg-yellow-600"
           >
             Donate
           </a>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -21,9 +21,15 @@ export function Dialog({ open, onOpenChange, children }: DialogProps) {
   );
 }
 
-export function DialogContent({ children }: { children: ReactNode }) {
+export function DialogContent({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
   return (
-    <div className="bg-white p-6 rounded shadow-lg max-w-sm w-full">
+    <div className={`bg-white p-6 rounded shadow-lg max-w-sm w-full ${className}`.trim()}>
       {children}
     </div>
   );

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -35,10 +35,28 @@ export function DialogContent({
   );
 }
 
-export function DialogTitle({ children }: { children: ReactNode }) {
-  return <h2 className="text-lg font-bold">{children}</h2>;
+export function DialogTitle({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <h2 className={`text-lg font-bold ${className}`.trim()}>{children}</h2>
+  );
 }
 
-export function DialogDescription({ children }: { children: ReactNode }) {
-  return <p className="mt-2 text-sm text-gray-600">{children}</p>;
+export function DialogDescription({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`mt-2 text-sm text-gray-600 ${className}`.trim()}>
+      {children}
+    </div>
+  );
 }

--- a/hooks/useDonationOverlay.ts
+++ b/hooks/useDonationOverlay.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+
+const DONATION_THRESHOLD = 50;
+const LATER_DELAY_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
+
+export function useDonationOverlay(userProfile: any, playersCount: number) {
+  const [showOverlay, setShowOverlay] = useState(false);
+
+  useEffect(() => {
+    if (!userProfile) return;
+
+    const isFree = userProfile.paying_status === "free";
+    const donationDate = userProfile.donation_date
+      ? new Date(userProfile.donation_date)
+      : null;
+
+    // If donated less than a year ago, suppress
+    if (userProfile.paying_status === "donated" && donationDate) {
+      const oneYearLater = new Date(donationDate);
+      oneYearLater.setFullYear(oneYearLater.getFullYear() + 1);
+      if (new Date() < oneYearLater) return;
+    }
+
+    // Check if "Later" was clicked recently
+    const hideUntil = localStorage.getItem("hideDonateOverlayUntil");
+    if (hideUntil && Date.now() < parseInt(hideUntil)) return;
+
+    if (isFree && playersCount >= DONATION_THRESHOLD) {
+      setShowOverlay(true);
+    }
+  }, [userProfile, playersCount]);
+
+  const dismissTemporarily = () => {
+    localStorage.setItem(
+      "hideDonateOverlayUntil",
+      (Date.now() + LATER_DELAY_MS).toString()
+    );
+    setShowOverlay(false);
+  };
+
+  return { showOverlay, dismissTemporarily };
+}


### PR DESCRIPTION
## Summary
- add `useDonationOverlay` hook with delay logic
- update `DialogContent` to accept `className`
- modernize `DonationModal`
- fetch user profile fields and show donation overlay in Players view

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889b578b1e083308b71106e76c74d2c