### PR TITLE
Fix stripe webhook header retrieval

### DIFF
--- a/app/api/stripe-webhook/route.ts
+++ b/app/api/stripe-webhook/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
   if (!webhookSecret) {
     return NextResponse.json({ error: "Missing webhook secret" }, { status: 500 });
   }
-  const signature = getHeaders().get("stripe-signature");
+  const signature = (await getHeaders()).get("stripe-signature");
   if (!signature) {
     return NextResponse.json({ error: "Missing signature" }, { status: 400 });
   }


### PR DESCRIPTION
## Summary
- await the headers() call so TypeScript knows it resolves to ReadonlyHeaders

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688a332b815c8330b9c1e4027d42f614