### PR TITLE
Fix Supabase user lookup

### DIFF
--- a/app/api/stripe-webhook/route.ts
+++ b/app/api/stripe-webhook/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
   if (!webhookSecret) {
     return NextResponse.json({ error: "Missing webhook secret" }, { status: 500 });
   }
-  const signature = getHeaders().get("stripe-signature");
+  const signature = (await getHeaders()).get("stripe-signature");
   if (!signature) {
     return NextResponse.json({ error: "Missing signature" }, { status: 400 });
   }
@@ -48,7 +48,8 @@ export async function POST(req: NextRequest) {
     const email = event.data?.object?.customer_details?.email;
     if (email && supabaseUrl && serviceRoleKey) {
       const supabase = createClient(supabaseUrl, serviceRoleKey);
-      const { data: user } = await supabase.auth.admin.getUserByEmail(email);
+      const { data } = await supabase.auth.admin.listUsers();
+      const user = data?.users?.find((u) => u.email?.toLowerCase() === email.toLowerCase());
       const userId = user?.id;
       if (userId) {
         await supabase


### PR DESCRIPTION
## Summary
- query the admin API listUsers endpoint and match by email

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688a332b815c8330b9c1e4027d42f614