### PR TITLE
Improve Stripe webhook logging

### DIFF
--- a/app/api/stripe-webhook/route.ts
+++ b/app/api/stripe-webhook/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { headers as getHeaders } from "next/headers";
 import { createClient } from "@supabase/supabase-js";
 import { createHmac, timingSafeEqual } from "crypto";
+import { logServer } from "@/utils/logger";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
@@ -27,10 +28,12 @@ function verifySignature(body: string, sigHeader: string, secret: string) {
 
 export async function POST(req: NextRequest) {
   if (!webhookSecret) {
+    await logServer("stripe webhook missing secret");
     return NextResponse.json({ error: "Missing webhook secret" }, { status: 500 });
   }
   const signature = (await getHeaders()).get("stripe-signature");
   if (!signature) {
+    await logServer("stripe webhook missing signature");
     return NextResponse.json({ error: "Missing signature" }, { status: 400 });
   }
 
@@ -38,28 +41,44 @@ export async function POST(req: NextRequest) {
 
   try {
     verifySignature(body, signature, webhookSecret);
+    await logServer("stripe signature verified");
   } catch {
+    await logServer("stripe webhook invalid signature", { signature });
     return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
   }
 
   const event = JSON.parse(body);
+  await logServer("stripe event received", { type: event.type });
 
   if (event.type === "checkout.session.completed") {
     const email = event.data?.object?.customer_details?.email;
     if (email && supabaseUrl && serviceRoleKey) {
       const supabase = createClient(supabaseUrl, serviceRoleKey);
-      const { data } = await supabase.auth.admin.listUsers();
+      const { data, error } = await supabase.auth.admin.listUsers();
+      if (error) {
+        await logServer("listUsers error", error);
+      }
       const user = data?.users?.find((u) => u.email?.toLowerCase() === email.toLowerCase());
       const userId = user?.id;
       if (userId) {
-        await supabase
+        await logServer("updating user profile", { userId });
+        const { error: updateError } = await supabase
           .from("user_profiles")
           .update({
             paying_status: "donated",
             donation_date: new Date().toISOString(),
           })
           .eq("user_id", userId);
+        if (updateError) {
+          await logServer("profile update failed", updateError);
+        } else {
+          await logServer("profile updated", { userId });
+        }
+      } else {
+        await logServer("user not found for email", { email });
       }
+    } else {
+      await logServer("webhook missing email or env vars", { email });
     }
   }
 

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,4 +1,5 @@
 import { supabase } from '../lib/supabaseBrowser'
+import { createClient } from '@supabase/supabase-js'
 
 export async function logDebug(message: string, data?: unknown) {
   try {
@@ -6,5 +7,21 @@ export async function logDebug(message: string, data?: unknown) {
     await supabase.from('logs').insert({ message: text })
   } catch (err) {
     console.error('logDebug failed', err)
+  }
+}
+
+export async function logServer(message: string, data?: unknown) {
+  try {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string
+    if (!supabaseUrl || !serviceRoleKey) {
+      console.error('Missing Supabase env vars for logServer')
+      return
+    }
+    const serverClient = createClient(supabaseUrl, serviceRoleKey)
+    const text = data ? `${message}: ${JSON.stringify(data)}` : message
+    await serverClient.from('logs').insert({ message: text })
+  } catch (err) {
+    console.error('logServer failed', err)
   }
 }


### PR DESCRIPTION
## Summary
- add server-side logging util
- log webhook workflow events for Stripe payments

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688a37fcf40c8330bff43949274216c9