### PR TITLE
Add Stripe webhook middleware

### DIFF
--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Allow Stripe webhook without auth
+  if (pathname.startsWith("/api/stripe-webhook")) {
+    return NextResponse.next();
+  }
+
+  // Other routes can be protected (if needed)
+  return NextResponse.next();
+}
+
+// Only run this middleware for these paths
+export const config = {
+  matcher: ["/api/stripe-webhook"],
+};


### PR DESCRIPTION
## Summary
- add `app/middleware.ts` to allow `/api/stripe-webhook` route

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a459ae4148330964492c989ef0ef6