### PR TITLE
Fix thank-you modal closing

### DIFF
--- a/components/PlayersView.tsx
+++ b/components/PlayersView.tsx
@@ -17,7 +17,7 @@ export default function PlayersView() {
   const [filter, setFilter] = useState<string>("");
   const [userProfile, setUserProfile] = useState<any | null>(null);
 
-  const { status, dismissTemporarily } = useDonationOverlay(
+  const { status, dismissTemporarily, dismissThankYou } = useDonationOverlay(
     userProfile,
     players.length
   );
@@ -207,16 +207,7 @@ export default function PlayersView() {
         />
       )}
 
-      {status === "thankyou" && (
-        <ThankYouModal
-          onClose={() =>
-            localStorage.setItem(
-              "hideDonateOverlayUntil",
-              Date.now().toString()
-            )
-          }
-        />
-      )}
+      {status === "thankyou" && <ThankYouModal onClose={dismissThankYou} />}
 
       <div className="max-w-2xl mx-auto p-6">
       <h1 className="text-xl font-bold mb-4 flex items-baseline gap-2">

--- a/hooks/useDonationOverlay.ts
+++ b/hooks/useDonationOverlay.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 
 export function useDonationOverlay(userProfile: any, playersCount: number) {
-  const [status, setStatus] = useState<"show" | "thankyou" | "hidden">("hidden");
+  const [status, setStatus] =
+    useState<"show" | "thankyou" | "hidden">("hidden");
 
   useEffect(() => {
     if (!userProfile) return;
@@ -18,7 +19,7 @@ export function useDonationOverlay(userProfile: any, playersCount: number) {
       const oneYearLater = new Date(donationDate);
       oneYearLater.setFullYear(oneYearLater.getFullYear() + 1);
 
-      if (new Date() < oneYearLater) {
+      if (new Date() < oneYearLater && !suppressed) {
         setStatus("thankyou");
         return;
       }
@@ -43,5 +44,20 @@ export function useDonationOverlay(userProfile: any, playersCount: number) {
     setStatus("hidden");
   };
 
-  return { status, dismissTemporarily };
+  const dismissThankYou = () => {
+    const donationDate = userProfile?.donation_date
+      ? new Date(userProfile.donation_date)
+      : null;
+
+    let hideUntil = Date.now() + 365 * 86400000;
+    if (donationDate) {
+      const oneYearLater = new Date(donationDate);
+      oneYearLater.setFullYear(oneYearLater.getFullYear() + 1);
+      hideUntil = oneYearLater.getTime();
+    }
+    localStorage.setItem("hideDonateOverlayUntil", hideUntil.toString());
+    setStatus("hidden");
+  };
+
+  return { status, dismissTemporarily, dismissThankYou };
 }


### PR DESCRIPTION
## Summary
- handle closing of thank you overlay by updating overlay hook
- add dismiss logic to close the modal from the players view

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_688b29f51b7c83309815fb931627a559