### PR TITLE
Fix missing auth session error in Header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,15 +19,15 @@ export default function Header() {
 
   useEffect(() => {
     supabase.auth
-      .getUser()
+      .getSession()
       .then(({ data, error }) => {
         if (error) {
-          console.error("getUser error", error.message);
+          console.error("getSession error", error.message);
         }
-        setUserEmail(data.user?.email ?? null);
+        setUserEmail(data.session?.user?.email ?? null);
       })
       .catch((err) => {
-        console.error("getUser failed", err?.message);
+        console.error("getSession failed", err?.message);
         setUserEmail(null);
       });
     const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {


### PR DESCRIPTION
## Summary
- use `getSession` in Header to avoid "Auth session missing" errors when fetching user

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: requires ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_688f070a6c888330b77c835d2c2fccb9