### PR TITLE
Fix missing auth session error in Header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -18,18 +18,21 @@ export default function Header() {
   const [userEmail, setUserEmail] = useState<string | null>(null);
 
   useEffect(() => {
+    // Fetch the existing session on mount. Using getSession avoids "Auth session missing" errors
+    // that occurred with getUser when no active session was present.
     supabase.auth
-      .getUser()
+      .getSession()
       .then(({ data, error }) => {
         if (error) {
-          console.error("getUser error", error.message);
+          console.error("getSession error", error.message);
         }
-        setUserEmail(data.user?.email ?? null);
+        setUserEmail(data.session?.user?.email ?? null);
       })
       .catch((err) => {
-        console.error("getUser failed", err?.message);
+        console.error("getSession failed", err?.message);
         setUserEmail(null);
       });
+    // Subscribe to auth changes to update the displayed email when the session changes.
     const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {
       setUserEmail(session?.user?.email ?? null);
     });


### PR DESCRIPTION
## Summary
- use `getSession` in Header to avoid "Auth session missing" errors when fetching user
- document the new session-based logic in Header's comments

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_688f070a6c888330b77c835d2c2fccb9