### PR TITLE
Replace login overlay with redirect to login page

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Header from "../components/Header";
-import LoginOverlay from "../components/LoginOverlay";
+import AuthRedirect from "../components/AuthRedirect";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,10 +30,10 @@ export default function RootLayout({
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <LoginOverlay>
+        <AuthRedirect>
           <Header />
           <main className="p-4">{children}</main>
-        </LoginOverlay>
+        </AuthRedirect>
       </body>
     </html>
   );

--- a/components/AuthRedirect.tsx
+++ b/components/AuthRedirect.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { supabase } from "@/lib/supabaseBrowser";
+
+export default function AuthRedirect({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const isPublic =
+    pathname === "/" ||
+    pathname === "/create" ||
+    pathname === "/demo" ||
+    pathname === "/login" ||
+    pathname === "/register" ||
+    pathname === "/reset" ||
+    pathname.includes("/public");
+
+  useEffect(() => {
+    if (isPublic) return;
+    supabase.auth.getUser().then(({ data }) => {
+      if (!data.user) {
+        router.replace("/login");
+      }
+    });
+  }, [isPublic, router]);
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- add AuthRedirect component to send unauthenticated users to the new login page
- integrate AuthRedirect in the root layout replacing the old overlay wrapper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688f0baba6a08330a57583408df019b9