### PR TITLE
Replace login overlay with redirect to login page

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Header from "../components/Header";
-import LoginOverlay from "../components/LoginOverlay";
+import AuthRedirect from "../components/AuthRedirect";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,10 +30,10 @@ export default function RootLayout({
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <LoginOverlay>
+        <AuthRedirect>
           <Header />
           <main className="p-4">{children}</main>
-        </LoginOverlay>
+        </AuthRedirect>
       </body>
     </html>
   );

--- a/components/AuthButtons.tsx
+++ b/components/AuthButtons.tsx
@@ -1,8 +1,10 @@
 "use client";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { supabase } from "../lib/supabaseBrowser";
 
 export default function AuthButtons() {
+  const router = useRouter();
   const [user, setUser] = useState<any>(null);
 
   useEffect(() => {
@@ -30,11 +32,13 @@ export default function AuthButtons() {
     const { error } = await supabase.auth.signOut();
     if (error) {
       console.error('logout error', error.message);
+      return;
     }
+    router.push('/');
   };
 
   const login = () => {
-    // Login overlay appears automatically when no user
+    router.push('/login');
   };
 
   return user ? (

--- a/components/AuthRedirect.tsx
+++ b/components/AuthRedirect.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { supabase } from "@/lib/supabaseBrowser";
+
+export default function AuthRedirect({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const isPublic =
+    pathname === "/" ||
+    pathname === "/create" ||
+    pathname === "/demo" ||
+    pathname === "/login" ||
+    pathname === "/register" ||
+    pathname === "/reset" ||
+    pathname.includes("/public");
+
+  useEffect(() => {
+    if (isPublic) return;
+    supabase.auth.getUser().then(({ data }) => {
+      if (!data.user) {
+        router.replace("/login");
+      }
+    });
+  }, [isPublic, router]);
+
+  return <>{children}</>;
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { supabase } from "../lib/supabaseBrowser";
@@ -15,6 +15,7 @@ const tabs = [
 
 export default function Header() {
   const pathname = usePathname();
+  const router = useRouter();
   const [userEmail, setUserEmail] = useState<string | null>(null);
 
   useEffect(() => {
@@ -42,7 +43,9 @@ export default function Header() {
     const { error } = await supabase.auth.signOut();
     if (error) {
       console.error("logout error", error.message);
+      return;
     }
+    router.push("/");
   };
 
   return (
@@ -61,15 +64,22 @@ export default function Header() {
           </div>
         </div>
 
-        {/* Right: Logout */}
+        {/* Right: Auth */}
         <div className="flex items-center gap-4">
-          {userEmail && (
+          {userEmail ? (
             <button
               onClick={onLogout}
               className="text-sm text-gray-600 bg-gray-100 px-3 py-1.5 rounded hover:bg-gray-200 transition"
             >
               Logout
             </button>
+          ) : (
+            <Link
+              href="/login"
+              className="text-sm text-gray-600 bg-gray-100 px-3 py-1.5 rounded hover:bg-gray-200 transition"
+            >
+              Login
+            </Link>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- redirect sign-outs to the public landing page and show a login link for logged-out users
- update AuthButtons to navigate to the new login page
- keep AuthRedirect to send unauthenticated visitors to the login screen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run build` *(fails: could not fetch Geist fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688f0baba6a08330a57583408df019b9