### PR TITLE
feat: add automatic user profile sync

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -39,6 +39,34 @@ export default function Header() {
     };
   }, []);
 
+  useEffect(() => {
+    const ensureUserProfile = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) return;
+
+      const { data, error } = await supabase
+        .from('user_profiles')
+        .select('id')
+        .eq('id', user.id)
+        .single();
+
+      if (!data && !error) {
+        await supabase.from('user_profiles').insert({
+          id: user.id,
+          email: user.email,
+          created_at: new Date().toISOString(),
+          paying_status: 'free',
+          selected_sport: 'babyfoot',
+        });
+      }
+    };
+
+    ensureUserProfile();
+  }, []);
+
   const onLogout = async () => {
     const { error } = await supabase.auth.signOut();
     if (error) {


### PR DESCRIPTION
## Summary
- ensure a `user_profiles` row exists for the signed-in user by inserting a default profile if necessary

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for configuration)*
- `npm run build` *(fails: Failed to fetch fonts from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688f181850648330b64954d23516f4d7