### PR TITLE
feat: show app version in settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 OPENAI_API_KEY=your_openai_api_key
+NEXT_PUBLIC_APP_VERSION=1.2.0

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -346,6 +346,11 @@ export default function SettingsPage() {
           </Button>
         </div>
       </section>
+
+      {/* App version */}
+      <div className="mt-8 text-center text-sm text-gray-400">
+        MyTournamentApp v{process.env.NEXT_PUBLIC_APP_VERSION || "1.0.0"}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- display app version at the bottom of settings page
- document `NEXT_PUBLIC_APP_VERSION` in `.env.example`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688f20bbd8e88330831f941885d08809