### PR TITLE
docs: add RLS setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 ## Backend Setup
 
 1. Create a [Supabase](https://supabase.com) project.
-2. In the Supabase dashboard create three tables:
+2. In the Supabase dashboard create the following tables:
    - **players** with columns `id` (uuid, primary key), `name` (text), `offense` (int4), `defense` (int4).
    - **tournaments** with columns `id` (uuid, primary key) and `name` (text).
+   - **tournament_teams** with columns `tournament_id` (uuid, references `tournaments.id`) and `team_id` (uuid, references `teams.id`).
    - **user_profiles** with column `user_id` (uuid, primary key).
 3. Run the following SQL so a profile row is automatically created whenever a new user signs up:
 
@@ -27,6 +28,7 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 5. In the **Email** settings choose **Email OTP** for "Confirm signup" so new accounts receive a numeric code instead of a magic link. Also set the password recovery redirect URL to `<your site>/reset` so the reset link leads to the page for choosing a new password.
 6. Set the SMTP settings to use your [Resend](https://resend.com) credentials so Supabase will send the emails via Resend.
 7. Grab the project URL and anon key from the Supabase settings and add them to an `.env` file using the variables shown in `.env.example`.
+8. Enable Row Level Security on the `players` and `tournament_teams` tables by running the SQL in [`scripts/enable_rls.sql`](./scripts/enable_rls.sql) using the Supabase SQL editor.
 
 ## Authentication
 

--- a/scripts/enable_rls.sql
+++ b/scripts/enable_rls.sql
@@ -1,0 +1,33 @@
+-- Enable Row Level Security on public tables and define basic policies
+
+-- Tournament teams table
+ALTER TABLE public.tournament_teams ENABLE ROW LEVEL SECURITY;
+
+-- Allow authenticated users to manage tournament teams for their own tournaments
+CREATE POLICY "tournament_teams_owner_all"
+  ON public.tournament_teams
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.tournaments t
+      WHERE t.id = tournament_id AND t.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.tournaments t
+      WHERE t.id = tournament_id AND t.user_id = auth.uid()
+    )
+  );
+
+-- Players table
+ALTER TABLE public.players ENABLE ROW LEVEL SECURITY;
+
+-- Allow authenticated users to access only their own players
+CREATE POLICY "players_owner_all"
+  ON public.players
+  FOR ALL
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- document enabling row-level security on Supabase tables
- include SQL script with policies for `tournament_teams` and `players`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a719ad8ffc833095828514cce2d2ca